### PR TITLE
Database writes in computation thread

### DIFF
--- a/app/src/main/java/io/reark/rxgithubapp/data/stores/GitHubRepositorySearchStore.java
+++ b/app/src/main/java/io/reark/rxgithubapp/data/stores/GitHubRepositorySearchStore.java
@@ -27,7 +27,7 @@ public class GitHubRepositorySearchStore extends SingleItemContentProviderStore<
     @NonNull
     @Override
     protected String getIdFor(@NonNull GitHubRepositorySearch item) {
-        Preconditions.checkNotNull(item, "Github Repository Search cannot be null.");
+        Preconditions.checkNotNull(item, "GitHub Repository Search cannot be null.");
 
         return item.getSearch();
     }
@@ -63,9 +63,23 @@ public class GitHubRepositorySearchStore extends SingleItemContentProviderStore<
 
     @NonNull
     @Override
+    protected ContentValues readRaw(Cursor cursor) {
+        final String json = cursor.getString(cursor.getColumnIndex(GitHubRepositorySearchColumns.JSON));
+        ContentValues contentValues = new ContentValues();
+        contentValues.put(GitHubRepositorySearchColumns.JSON, json);
+        return contentValues;
+    }
+
+    @NonNull
+    @Override
     public Uri getUriForKey(@NonNull String id) {
         Preconditions.checkNotNull(id, "Id cannot be null.");
 
         return GitHubProvider.GitHubRepositorySearches.withSearch(id);
+    }
+
+    @Override
+    protected boolean contentValuesEqual(ContentValues v1, ContentValues v2) {
+        return v1.getAsString(GitHubRepositorySearchColumns.JSON).equals(v2.getAsString(GitHubRepositorySearchColumns.JSON));
     }
 }

--- a/app/src/main/java/io/reark/rxgithubapp/data/stores/GitHubRepositoryStore.java
+++ b/app/src/main/java/io/reark/rxgithubapp/data/stores/GitHubRepositoryStore.java
@@ -28,7 +28,7 @@ public class GitHubRepositoryStore extends SingleItemContentProviderStore<GitHub
     @NonNull
     @Override
     protected Integer getIdFor(@NonNull GitHubRepository item) {
-        Preconditions.checkNotNull(item, "Github Repository cannot be null.");
+        Preconditions.checkNotNull(item, "GitHub Repository cannot be null.");
 
         return item.getId();
     }
@@ -65,9 +65,23 @@ public class GitHubRepositoryStore extends SingleItemContentProviderStore<GitHub
 
     @NonNull
     @Override
+    protected ContentValues readRaw(Cursor cursor) {
+        final String json = cursor.getString(cursor.getColumnIndex(JsonIdColumns.JSON));
+        ContentValues contentValues = new ContentValues();
+        contentValues.put(JsonIdColumns.JSON, json);
+        return contentValues;
+    }
+
+    @NonNull
+    @Override
     public Uri getUriForKey(@NonNull Integer id) {
         Preconditions.checkNotNull(id, "Id cannot be null.");
 
         return GitHubProvider.GitHubRepositories.withId(id);
+    }
+
+    @Override
+    protected boolean contentValuesEqual(ContentValues v1, ContentValues v2) {
+        return v1.getAsString(JsonIdColumns.JSON).equals(v2.getAsString(JsonIdColumns.JSON));
     }
 }

--- a/app/src/main/java/io/reark/rxgithubapp/data/stores/NetworkRequestStatusStore.java
+++ b/app/src/main/java/io/reark/rxgithubapp/data/stores/NetworkRequestStatusStore.java
@@ -72,9 +72,23 @@ public class NetworkRequestStatusStore extends SingleItemContentProviderStore<Ne
 
     @NonNull
     @Override
+    protected ContentValues readRaw(Cursor cursor) {
+        final String json = cursor.getString(cursor.getColumnIndex(JsonIdColumns.JSON));
+        ContentValues contentValues = new ContentValues();
+        contentValues.put(JsonIdColumns.JSON, json);
+        return contentValues;
+    }
+
+    @NonNull
+    @Override
     public Uri getUriForKey(@NonNull Integer id) {
         Preconditions.checkNotNull(id, "Id cannot be null.");
 
         return GitHubProvider.NetworkRequestStatuses.withId(id);
+    }
+
+    @Override
+    protected boolean contentValuesEqual(ContentValues v1, ContentValues v2) {
+        return v1.getAsString(JsonIdColumns.JSON).equals(v2.getAsString(JsonIdColumns.JSON));
     }
 }

--- a/app/src/main/java/io/reark/rxgithubapp/data/stores/UserSettingsStore.java
+++ b/app/src/main/java/io/reark/rxgithubapp/data/stores/UserSettingsStore.java
@@ -70,6 +70,14 @@ public class UserSettingsStore extends SingleItemContentProviderStore<UserSettin
         return value;
     }
 
+    @NonNull
+    @Override
+    protected ContentValues readRaw(Cursor cursor) {
+        final String json = cursor.getString(cursor.getColumnIndex(JsonIdColumns.JSON));
+        ContentValues contentValues = new ContentValues();
+        contentValues.put(JsonIdColumns.JSON, json);
+        return contentValues;
+    }
 
     @NonNull
     @Override
@@ -77,5 +85,10 @@ public class UserSettingsStore extends SingleItemContentProviderStore<UserSettin
         Preconditions.checkNotNull(id, "Id cannot be null.");
 
         return GitHubProvider.UserSettings.withId(id);
+    }
+
+    @Override
+    protected boolean contentValuesEqual(ContentValues v1, ContentValues v2) {
+        return v1.getAsString(JsonIdColumns.JSON).equals(v2.getAsString(JsonIdColumns.JSON));
     }
 }

--- a/reark/src/main/java/io/reark/reark/data/store/ContentProviderStore.java
+++ b/reark/src/main/java/io/reark/reark/data/store/ContentProviderStore.java
@@ -10,11 +10,15 @@ import android.os.HandlerThread;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.util.Log;
+import android.util.Pair;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import io.reark.reark.utils.Preconditions;
+import rx.Observable;
+import rx.schedulers.Schedulers;
+import rx.subjects.PublishSubject;
 
 /**
  * Created by ttuo on 26/04/15.
@@ -28,10 +32,32 @@ public abstract class ContentProviderStore<T> {
     @NonNull
     private final ContentObserver contentObserver = getContentObserver();
 
+    protected final PublishSubject<Pair<T, Uri>> updateSubject = PublishSubject.create();
+
     public ContentProviderStore(ContentResolver contentResolver) {
         this.contentResolver = contentResolver;
         this.contentResolver.registerContentObserver(
                 getContentUri(), true, contentObserver);
+
+        subscribe();
+    }
+
+    private void subscribe() {
+        updateSubject
+                .onBackpressureBuffer()
+                .observeOn(Schedulers.computation())
+                .subscribe(pair -> {
+                    ContentValues values = getContentValuesForItem(pair.first);
+                    Log.v(TAG, "insertOrUpdate to " + pair.second);
+                    Log.v(TAG, "values(" + values + ")");
+
+                    if (contentResolver.update(pair.second, values, null, null) == 0) {
+                        final Uri resultUri = contentResolver.insert(pair.second, values);
+                        Log.v(TAG, "Inserted at " + resultUri);
+                    } else {
+                        Log.v(TAG, "Updated at " + pair.second);
+                    }
+                });
     }
 
     @NonNull
@@ -44,23 +70,14 @@ public abstract class ContentProviderStore<T> {
     protected void insertOrUpdate(T item, Uri uri) {
         Preconditions.checkNotNull(item, "Item to be inserted cannot be null");
 
-        Log.v(TAG, "insertOrUpdate to " + uri);
-        ContentValues values = getContentValuesForItem(item);
-        Log.v(TAG, "values(" + values + ")");
-        if (contentResolver.update(uri, values, null, null) == 0) {
-            final Uri resultUri = contentResolver.insert(uri, values);
-            Log.v(TAG, "Inserted at " + resultUri);
-        } else {
-            Log.v(TAG, "Updated at " + uri);
-        }
+        updateSubject.onNext(new Pair<>(item, uri));
     }
 
     @NonNull
     protected List<T> queryList(Uri uri) {
-        Preconditions.checkNotNull(uri, "Uri cannot be null");
+        Preconditions.checkNotNull(uri, "Uri cannot be null.");
 
-        Cursor cursor = contentResolver.query(uri,
-                getProjection(), null, null, null);
+        Cursor cursor = contentResolver.query(uri, getProjection(), null, null, null);
         List<T> list = new ArrayList<>();
 
         if (cursor != null) {
@@ -78,7 +95,7 @@ public abstract class ContentProviderStore<T> {
         return list;
     }
 
-    @Nullable
+    @NonNull
     protected T queryOne(Uri uri) {
         final List<T> queryResults = queryList(uri);
 

--- a/reark/src/main/java/io/reark/reark/data/store/SingleItemContentProviderStore.java
+++ b/reark/src/main/java/io/reark/reark/data/store/SingleItemContentProviderStore.java
@@ -4,6 +4,7 @@ import android.content.ContentResolver;
 import android.database.ContentObserver;
 import android.net.Uri;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.util.Log;
 
 import java.util.concurrent.ConcurrentHashMap;
@@ -54,7 +55,6 @@ abstract public class SingleItemContentProviderStore<T, U> extends ContentProvid
         Preconditions.checkNotNull(id, "Id cannot be null.");
 
         Log.v(TAG, "getStream(" + id + ")");
-
         final T item = query(id);
         final Observable<T> observable = lazyGetSubject(id);
         if (item != null) {
@@ -74,7 +74,7 @@ abstract public class SingleItemContentProviderStore<T, U> extends ContentProvid
         return subjectMap.get(uri);
     }
 
-    @NonNull
+    @Nullable
     protected T query(@NonNull U id) {
         Preconditions.checkNotNull(id, "Id cannot be null.");
 

--- a/reark/src/main/java/io/reark/reark/data/store/SingleItemContentProviderStore.java
+++ b/reark/src/main/java/io/reark/reark/data/store/SingleItemContentProviderStore.java
@@ -4,7 +4,6 @@ import android.content.ContentResolver;
 import android.database.ContentObserver;
 import android.net.Uri;
 import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import android.util.Log;
 
 import java.util.concurrent.ConcurrentHashMap;
@@ -55,6 +54,7 @@ abstract public class SingleItemContentProviderStore<T, U> extends ContentProvid
         Preconditions.checkNotNull(id, "Id cannot be null.");
 
         Log.v(TAG, "getStream(" + id + ")");
+
         final T item = query(id);
         final Observable<T> observable = lazyGetSubject(id);
         if (item != null) {
@@ -74,7 +74,7 @@ abstract public class SingleItemContentProviderStore<T, U> extends ContentProvid
         return subjectMap.get(uri);
     }
 
-    @Nullable
+    @NonNull
     protected T query(@NonNull U id) {
         Preconditions.checkNotNull(id, "Id cannot be null.");
 


### PR DESCRIPTION
Move db writes into computation thread. Also, avoids writes if the new values are identical to existing ones. This reduces UI flickering when values are updated for no reason.