### PR TITLE
Add a method for subscribing only when not subscribed yet

### DIFF
--- a/reark/src/main/java/io/reark/reark/viewmodels/AbstractViewModel.java
+++ b/reark/src/main/java/io/reark/reark/viewmodels/AbstractViewModel.java
@@ -14,9 +14,11 @@ abstract public class AbstractViewModel {
 
     final public void subscribeToDataStore() {
         Log.v(TAG, "subscribeToDataStore");
-        unsubscribeFromDataStore();
-        compositeSubscription = new CompositeSubscription();
-        subscribeToDataStoreInternal(compositeSubscription);
+
+        if (compositeSubscription == null) {
+            compositeSubscription = new CompositeSubscription();
+            subscribeToDataStoreInternal(compositeSubscription);
+        }
     }
 
     public void dispose() {
@@ -34,6 +36,7 @@ abstract public class AbstractViewModel {
 
     public void unsubscribeFromDataStore() {
         Log.v(TAG, "unsubscribeToDataStore");
+
         if (compositeSubscription != null) {
             compositeSubscription.clear();
             compositeSubscription = null;


### PR DESCRIPTION
By default ViewModel's subscribe() unsubscribes any existing subscription before re-subscribing. Add a method for skipping this in case we're happy with the existing subscription.