### PR TITLE
Implement named fetchers

### DIFF
--- a/app/src/main/java/io/reark/rxgithubapp/data/DataLayer.java
+++ b/app/src/main/java/io/reark/rxgithubapp/data/DataLayer.java
@@ -14,6 +14,7 @@ import io.reark.rxgithubapp.data.stores.GitHubRepositoryStore;
 import io.reark.rxgithubapp.data.stores.NetworkRequestStatusStore;
 import io.reark.rxgithubapp.data.stores.UserSettingsStore;
 import io.reark.rxgithubapp.network.NetworkService;
+import io.reark.rxgithubapp.network.fetchers.GitHubRepositorySearchFetcher;
 import io.reark.rxgithubapp.pojo.GitHubRepository;
 import io.reark.rxgithubapp.pojo.GitHubRepositorySearch;
 import io.reark.rxgithubapp.pojo.UserSettings;
@@ -70,7 +71,13 @@ public class DataLayer extends DataLayerBase {
         Preconditions.checkNotNull(searchString, "Search string Store cannot be null.");
 
         Intent intent = new Intent(context, NetworkService.class);
+
+        // Fetchers can be identified either by contentUri, which selects first fetcher
+        // implementing the content type, or an identifier that can be used to choose a
+        // specific fetcher from multiple fetchers that return the same value types.
         intent.putExtra("contentUriString", gitHubRepositorySearchStore.getContentUri().toString());
+        intent.putExtra("fetcherIdentifier", GitHubRepositorySearchFetcher.IDENTIFIER);
+
         intent.putExtra("searchString", searchString);
         context.startService(intent);
     }

--- a/app/src/main/java/io/reark/rxgithubapp/network/ServiceDataLayer.java
+++ b/app/src/main/java/io/reark/rxgithubapp/network/ServiceDataLayer.java
@@ -46,10 +46,20 @@ public class ServiceDataLayer extends DataLayerBase {
     public void processIntent(@NonNull Intent intent) {
         Preconditions.checkNotNull(intent, "Intent cannot be null.");
 
+        final String fetcherIdentifier = intent.getStringExtra("fetcherIdentifier");
         final String contentUriString = intent.getStringExtra("contentUriString");
-        if (contentUriString != null) {
+
+        if (fetcherIdentifier != null) {
+            Fetcher matchingFetcher = findFetcherByIdentifier(fetcherIdentifier);
+            if (matchingFetcher != null) {
+                Log.v(TAG, "Fetcher found for " + fetcherIdentifier);
+                matchingFetcher.fetch(intent);
+            } else {
+                Log.e(TAG, "Unknown identifier " + fetcherIdentifier);
+            }
+        } else if (contentUriString != null) {
             final Uri contentUri = Uri.parse(contentUriString);
-            Fetcher matchingFetcher = findFetcher(contentUri);
+            Fetcher matchingFetcher = findFetcherByContentUri(contentUri);
             if (matchingFetcher != null) {
                 Log.v(TAG, "Fetcher found for " + contentUri);
                 matchingFetcher.fetch(intent);
@@ -57,12 +67,24 @@ public class ServiceDataLayer extends DataLayerBase {
                 Log.e(TAG, "Unknown Uri " + contentUri);
             }
         } else {
-            Log.e(TAG, "No Uri defined");
+            Log.e(TAG, "No fetcher found");
         }
     }
 
     @Nullable
-    private Fetcher findFetcher(@NonNull Uri contentUri) {
+    private Fetcher findFetcherByIdentifier(@NonNull String identifier) {
+        Preconditions.checkNotNull(identifier, "Identifier cannot be null.");
+
+        for (Fetcher fetcher : fetchers) {
+            if (fetcher.getIdentifier().equals(identifier)) {
+                return fetcher;
+            }
+        }
+        return null;
+    }
+
+    @Nullable
+    private Fetcher findFetcherByContentUri(@NonNull Uri contentUri) {
         Preconditions.checkNotNull(contentUri, "Content URL cannot be null.");
 
         for (Fetcher fetcher : fetchers) {

--- a/app/src/main/java/io/reark/rxgithubapp/network/fetchers/GitHubRepositoryFetcher.java
+++ b/app/src/main/java/io/reark/rxgithubapp/network/fetchers/GitHubRepositoryFetcher.java
@@ -20,6 +20,7 @@ import rx.schedulers.Schedulers;
  */
 public class GitHubRepositoryFetcher extends AppFetcherBase {
     private static final String TAG = GitHubRepositoryFetcher.class.getSimpleName();
+    public static final String IDENTIFIER = TAG;
 
     @NonNull
     private final GitHubRepositoryStore gitHubRepositoryStore;
@@ -32,6 +33,11 @@ public class GitHubRepositoryFetcher extends AppFetcherBase {
         Preconditions.checkNotNull(gitHubRepositoryStore, "GitHub Repository Store cannot be null.");
 
         this.gitHubRepositoryStore = gitHubRepositoryStore;
+    }
+
+    @Override
+    public String getIdentifier() {
+        return IDENTIFIER;
     }
 
     @Override

--- a/app/src/main/java/io/reark/rxgithubapp/network/fetchers/GitHubRepositorySearchFetcher.java
+++ b/app/src/main/java/io/reark/rxgithubapp/network/fetchers/GitHubRepositorySearchFetcher.java
@@ -26,6 +26,7 @@ import rx.schedulers.Schedulers;
  */
 public class GitHubRepositorySearchFetcher extends AppFetcherBase {
     private static final String TAG = GitHubRepositorySearchFetcher.class.getSimpleName();
+    public static final String IDENTIFIER = TAG;
 
     private final GitHubRepositoryStore gitHubRepositoryStore;
     private final GitHubRepositorySearchStore gitHubRepositorySearchStore;
@@ -42,6 +43,11 @@ public class GitHubRepositorySearchFetcher extends AppFetcherBase {
 
         this.gitHubRepositoryStore = gitHubRepositoryStore;
         this.gitHubRepositorySearchStore = gitHubRepositorySearchStore;
+    }
+
+    @Override
+    public String getIdentifier() {
+        return IDENTIFIER;
     }
 
     @Override

--- a/reark/src/main/java/io/reark/reark/network/fetchers/Fetcher.java
+++ b/reark/src/main/java/io/reark/reark/network/fetchers/Fetcher.java
@@ -7,6 +7,7 @@ import android.net.Uri;
  * Created by ttuo on 16/04/15.
  */
 public interface Fetcher {
+    String getIdentifier();
     void fetch(Intent intent);
     Uri getContentUri();
 }

--- a/reark/src/main/java/io/reark/reark/network/fetchers/FetcherBase.java
+++ b/reark/src/main/java/io/reark/reark/network/fetchers/FetcherBase.java
@@ -19,6 +19,7 @@ abstract public class FetcherBase implements Fetcher {
     private static final String TAG = FetcherBase.class.getSimpleName();
 
     public static final int NO_ERROR_CODE = -1;
+    public static String IDENTIFIER = "fetcherBase";
 
     private final Action1<NetworkRequestStatus> updateNetworkRequestStatus;
     protected final Map<Integer, Subscription> requestMap = new ConcurrentHashMap<>();


### PR DESCRIPTION
By default the used fetcher is chosen by content URI. We may however want to choose a specific fetcher in case of multiple fetchers implementing the same content URI. This patch adds fetcher identifiers that can be used to request a specific fetcher.