### PR TITLE
Use service URIs for fetcher matching

### DIFF
--- a/app/src/main/java/io/reark/rxgithubapp/data/DataLayer.java
+++ b/app/src/main/java/io/reark/rxgithubapp/data/DataLayer.java
@@ -13,6 +13,7 @@ import io.reark.rxgithubapp.data.stores.GitHubRepositorySearchStore;
 import io.reark.rxgithubapp.data.stores.GitHubRepositoryStore;
 import io.reark.rxgithubapp.data.stores.NetworkRequestStatusStore;
 import io.reark.rxgithubapp.data.stores.UserSettingsStore;
+import io.reark.rxgithubapp.network.GitHubService;
 import io.reark.rxgithubapp.network.NetworkService;
 import io.reark.rxgithubapp.pojo.GitHubRepository;
 import io.reark.rxgithubapp.pojo.GitHubRepositorySearch;
@@ -70,7 +71,7 @@ public class DataLayer extends DataLayerBase {
         Preconditions.checkNotNull(searchString, "Search string Store cannot be null.");
 
         Intent intent = new Intent(context, NetworkService.class);
-        intent.putExtra("contentUriString", gitHubRepositorySearchStore.getContentUri().toString());
+        intent.putExtra("serviceUriString", GitHubService.REPOSITORY_SEARCH.toString());
         intent.putExtra("searchString", searchString);
         context.startService(intent);
     }
@@ -92,7 +93,7 @@ public class DataLayer extends DataLayerBase {
 
     private void fetchGitHubRepository(@NonNull Integer repositoryId) {
         Intent intent = new Intent(context, NetworkService.class);
-        intent.putExtra("contentUriString", gitHubRepositoryStore.getContentUri().toString());
+        intent.putExtra("serviceUriString", GitHubService.REPOSITORY.toString());
         intent.putExtra("id", repositoryId);
         context.startService(intent);
     }

--- a/app/src/main/java/io/reark/rxgithubapp/network/GitHubService.java
+++ b/app/src/main/java/io/reark/rxgithubapp/network/GitHubService.java
@@ -1,5 +1,7 @@
 package io.reark.rxgithubapp.network;
 
+import android.net.Uri;
+
 import java.util.Map;
 
 import io.reark.rxgithubapp.pojo.GitHubRepository;
@@ -12,6 +14,9 @@ import rx.Observable;
  * Created by ttuo on 06/01/15.
  */
 public interface GitHubService {
+    static Uri REPOSITORY_SEARCH = Uri.parse("github/search");
+    static Uri REPOSITORY = Uri.parse("github/repository");
+
     @GET("/search/repositories")
     Observable<GitHubRepositorySearchResults> search(@QueryMap Map<String, String> search);
 

--- a/app/src/main/java/io/reark/rxgithubapp/network/ServiceDataLayer.java
+++ b/app/src/main/java/io/reark/rxgithubapp/network/ServiceDataLayer.java
@@ -46,15 +46,15 @@ public class ServiceDataLayer extends DataLayerBase {
     public void processIntent(@NonNull Intent intent) {
         Preconditions.checkNotNull(intent, "Intent cannot be null.");
 
-        final String contentUriString = intent.getStringExtra("contentUriString");
-        if (contentUriString != null) {
-            final Uri contentUri = Uri.parse(contentUriString);
-            Fetcher matchingFetcher = findFetcher(contentUri);
+        final String serviceUriString = intent.getStringExtra("serviceUriString");
+        if (serviceUriString != null) {
+            final Uri serviceUri = Uri.parse(serviceUriString);
+            Fetcher matchingFetcher = findFetcher(serviceUri);
             if (matchingFetcher != null) {
-                Log.v(TAG, "Fetcher found for " + contentUri);
+                Log.v(TAG, "Fetcher found for " + serviceUri);
                 matchingFetcher.fetch(intent);
             } else {
-                Log.e(TAG, "Unknown Uri " + contentUri);
+                Log.e(TAG, "Unknown Uri " + serviceUri);
             }
         } else {
             Log.e(TAG, "No Uri defined");
@@ -62,11 +62,11 @@ public class ServiceDataLayer extends DataLayerBase {
     }
 
     @Nullable
-    private Fetcher findFetcher(@NonNull Uri contentUri) {
-        Preconditions.checkNotNull(contentUri, "Content URL cannot be null.");
+    private Fetcher findFetcher(@NonNull Uri serviceUri) {
+        Preconditions.checkNotNull(serviceUri, "Service URI cannot be null.");
 
         for (Fetcher fetcher : fetchers) {
-            if (fetcher.getContentUri().equals(contentUri)) {
+            if (fetcher.getServiceUri().equals(serviceUri)) {
                 return fetcher;
             }
         }

--- a/app/src/main/java/io/reark/rxgithubapp/network/fetchers/GitHubRepositoryFetcher.java
+++ b/app/src/main/java/io/reark/rxgithubapp/network/fetchers/GitHubRepositoryFetcher.java
@@ -8,6 +8,7 @@ import android.util.Log;
 import io.reark.reark.pojo.NetworkRequestStatus;
 import io.reark.reark.utils.Preconditions;
 import io.reark.rxgithubapp.data.stores.GitHubRepositoryStore;
+import io.reark.rxgithubapp.network.GitHubService;
 import io.reark.rxgithubapp.network.NetworkApi;
 import io.reark.rxgithubapp.pojo.GitHubRepository;
 import rx.Observable;
@@ -71,7 +72,7 @@ public class GitHubRepositoryFetcher extends AppFetcherBase {
 
     @NonNull
     @Override
-    public Uri getContentUri() {
-        return gitHubRepositoryStore.getContentUri();
+    public Uri getServiceUri() {
+        return GitHubService.REPOSITORY;
     }
 }

--- a/app/src/main/java/io/reark/rxgithubapp/network/fetchers/GitHubRepositorySearchFetcher.java
+++ b/app/src/main/java/io/reark/rxgithubapp/network/fetchers/GitHubRepositorySearchFetcher.java
@@ -13,6 +13,7 @@ import io.reark.reark.pojo.NetworkRequestStatus;
 import io.reark.reark.utils.Preconditions;
 import io.reark.rxgithubapp.data.stores.GitHubRepositorySearchStore;
 import io.reark.rxgithubapp.data.stores.GitHubRepositoryStore;
+import io.reark.rxgithubapp.network.GitHubService;
 import io.reark.rxgithubapp.network.NetworkApi;
 import io.reark.rxgithubapp.pojo.GitHubRepository;
 import io.reark.rxgithubapp.pojo.GitHubRepositorySearch;
@@ -91,7 +92,7 @@ public class GitHubRepositorySearchFetcher extends AppFetcherBase {
 
     @NonNull
     @Override
-    public Uri getContentUri() {
-        return gitHubRepositorySearchStore.getContentUri();
+    public Uri getServiceUri() {
+        return GitHubService.REPOSITORY_SEARCH;
     }
 }

--- a/reark/src/main/java/io/reark/reark/network/fetchers/Fetcher.java
+++ b/reark/src/main/java/io/reark/reark/network/fetchers/Fetcher.java
@@ -8,5 +8,5 @@ import android.net.Uri;
  */
 public interface Fetcher {
     void fetch(Intent intent);
-    Uri getContentUri();
+    Uri getServiceUri();
 }


### PR DESCRIPTION
Content URIs are not perfect match for fetchers, since multiple endpoints
may return the same kind of content, rendering the URIs non-unique and thus
unfit for fetcher identification. Use service meta-URIs instead for this.