### PR TITLE
Move TextWatcherObservable to library

### DIFF
--- a/app/src/main/java/io/reark/rxgithubapp/view/RepositoriesView.java
+++ b/app/src/main/java/io/reark/rxgithubapp/view/RepositoriesView.java
@@ -17,7 +17,7 @@ import io.reark.reark.utils.Preconditions;
 import io.reark.reark.utils.RxViewBinder;
 import io.reark.rxgithubapp.R;
 import io.reark.rxgithubapp.pojo.GitHubRepository;
-import io.reark.rxgithubapp.utils.TextWatcherObservable;
+import io.reark.reark.utils.TextWatcherObservable;
 import io.reark.rxgithubapp.viewmodels.RepositoriesViewModel;
 import io.reark.rxgithubapp.viewmodels.RepositoriesViewModel.ProgressStatus;
 import rx.Observable;

--- a/reark/src/main/java/io/reark/reark/utils/TextWatcherObservable.java
+++ b/reark/src/main/java/io/reark/reark/utils/TextWatcherObservable.java
@@ -1,4 +1,4 @@
-package io.reark.rxgithubapp.utils;
+package io.reark.reark.utils;
 
 import android.support.annotation.NonNull;
 import android.text.Editable;


### PR DESCRIPTION
Simply move TextWatcherObservable to the library. Perhaps we an later replace it with another library, but for now it is useful to have.