### PR TITLE
Modify store get/put API for consistency

### DIFF
--- a/app/src/main/java/io/reark/rxgithubapp/data/DataLayer.java
+++ b/app/src/main/java/io/reark/rxgithubapp/data/DataLayer.java
@@ -48,7 +48,7 @@ public class DataLayer extends DataLayerBase {
     public Observable<DataStreamNotification<GitHubRepositorySearch>> getGitHubRepositorySearch(@NonNull final String searchString) {
         Preconditions.checkNotNull(searchString, "Search string Store cannot be null.");
 
-        final Uri uri = gitHubRepositorySearchStore.getUriForKey(searchString);
+        final Uri uri = gitHubRepositorySearchStore.getUriForId(searchString);
         final Observable<NetworkRequestStatus> networkRequestStatusObservable =
                 networkRequestStatusStore.getStream(uri.toString().hashCode());
         final Observable<GitHubRepositorySearch> gitHubRepositorySearchObservable =

--- a/app/src/main/java/io/reark/rxgithubapp/data/stores/GitHubRepositorySearchStore.java
+++ b/app/src/main/java/io/reark/rxgithubapp/data/stores/GitHubRepositorySearchStore.java
@@ -72,7 +72,7 @@ public class GitHubRepositorySearchStore extends SingleItemContentProviderStore<
 
     @NonNull
     @Override
-    public Uri getUriForKey(@NonNull String id) {
+    public Uri getUriForId(@NonNull String id) {
         Preconditions.checkNotNull(id, "Id cannot be null.");
 
         return GitHubProvider.GitHubRepositorySearches.withSearch(id);

--- a/app/src/main/java/io/reark/rxgithubapp/data/stores/GitHubRepositoryStore.java
+++ b/app/src/main/java/io/reark/rxgithubapp/data/stores/GitHubRepositoryStore.java
@@ -74,7 +74,7 @@ public class GitHubRepositoryStore extends SingleItemContentProviderStore<GitHub
 
     @NonNull
     @Override
-    public Uri getUriForKey(@NonNull Integer id) {
+    public Uri getUriForId(@NonNull Integer id) {
         Preconditions.checkNotNull(id, "Id cannot be null.");
 
         return GitHubProvider.GitHubRepositories.withId(id);

--- a/app/src/main/java/io/reark/rxgithubapp/data/stores/NetworkRequestStatusStore.java
+++ b/app/src/main/java/io/reark/rxgithubapp/data/stores/NetworkRequestStatusStore.java
@@ -43,7 +43,7 @@ public class NetworkRequestStatusStore extends SingleItemContentProviderStore<Ne
     public void put(@NonNull NetworkRequestStatus item) {
         Preconditions.checkNotNull(item, "Network Request Status cannot be null.");
 
-        Log.v(TAG, "insertOrUpdate(" + item.getStatus() + ", " + item.getUri() + ")");
+        Log.v(TAG, "put(" + item.getStatus() + ", " + item.getUri() + ")");
         super.put(item);
     }
 

--- a/app/src/main/java/io/reark/rxgithubapp/data/stores/NetworkRequestStatusStore.java
+++ b/app/src/main/java/io/reark/rxgithubapp/data/stores/NetworkRequestStatusStore.java
@@ -81,7 +81,7 @@ public class NetworkRequestStatusStore extends SingleItemContentProviderStore<Ne
 
     @NonNull
     @Override
-    public Uri getUriForKey(@NonNull Integer id) {
+    public Uri getUriForId(@NonNull Integer id) {
         Preconditions.checkNotNull(id, "Id cannot be null.");
 
         return GitHubProvider.NetworkRequestStatuses.withId(id);

--- a/app/src/main/java/io/reark/rxgithubapp/data/stores/UserSettingsStore.java
+++ b/app/src/main/java/io/reark/rxgithubapp/data/stores/UserSettingsStore.java
@@ -85,7 +85,7 @@ public class UserSettingsStore extends SingleItemContentProviderStore<UserSettin
 
     @NonNull
     @Override
-    public Uri getUriForKey(@NonNull Integer id) {
+    public Uri getUriForId(@NonNull Integer id) {
         Preconditions.checkNotNull(id, "Id cannot be null.");
 
         return GitHubProvider.UserSettings.withId(id);

--- a/app/src/main/java/io/reark/rxgithubapp/data/stores/UserSettingsStore.java
+++ b/app/src/main/java/io/reark/rxgithubapp/data/stores/UserSettingsStore.java
@@ -43,7 +43,7 @@ public class UserSettingsStore extends SingleItemContentProviderStore<UserSettin
     }
 
     private void initUserSettings() {
-        query(DataLayer.DEFAULT_USER_ID)
+        getOne(DataLayer.DEFAULT_USER_ID)
                 .first()
                 .filter(userSettings -> userSettings == null)
                 .subscribe(userSettings -> {

--- a/app/src/main/java/io/reark/rxgithubapp/network/fetchers/GitHubRepositoryFetcher.java
+++ b/app/src/main/java/io/reark/rxgithubapp/network/fetchers/GitHubRepositoryFetcher.java
@@ -54,7 +54,7 @@ public class GitHubRepositoryFetcher extends AppFetcherBase {
             Log.d(TAG, "Found an ongoing request for repository " + repositoryId);
             return;
         }
-        final String uri = gitHubRepositoryStore.getUriForKey(repositoryId).toString();
+        final String uri = gitHubRepositoryStore.getUriForId(repositoryId).toString();
         Subscription subscription = createNetworkObservable(repositoryId)
                 .subscribeOn(Schedulers.computation())
                 .doOnError(doOnError(uri))

--- a/app/src/main/java/io/reark/rxgithubapp/network/fetchers/GitHubRepositorySearchFetcher.java
+++ b/app/src/main/java/io/reark/rxgithubapp/network/fetchers/GitHubRepositorySearchFetcher.java
@@ -64,7 +64,7 @@ public class GitHubRepositorySearchFetcher extends AppFetcherBase {
             Log.d(TAG, "Found an ongoing request for repository " + searchString);
             return;
         }
-        final String uri = gitHubRepositorySearchStore.getUriForKey(searchString).toString();
+        final String uri = gitHubRepositorySearchStore.getUriForId(searchString).toString();
         Subscription subscription = createNetworkObservable(searchString)
                 .subscribeOn(Schedulers.computation())
                 .map((repositories) -> {

--- a/reark/src/main/java/io/reark/reark/data/store/ContentProviderStore.java
+++ b/reark/src/main/java/io/reark/reark/data/store/ContentProviderStore.java
@@ -20,7 +20,16 @@ import rx.schedulers.Schedulers;
 import rx.subjects.PublishSubject;
 
 /**
- * Created by ttuo on 26/04/15.
+ * ContentProviderStore implements an Observable based item store that uses a content provider as
+ * its data backing store.
+ *
+ * All content provider operations are threaded. The store executes put operations in order, but
+ * provides no guarantee for the execution order between get and put operations.
+ *
+ * This in an abstract class that implements the content provider access and expects extending
+ * classes to implement data type specific methods.
+ *
+ * @param <T> Type of the data this store contains.
  */
 public abstract class ContentProviderStore<T> {
     private static final String TAG = ContentProviderStore.class.getSimpleName();
@@ -34,7 +43,7 @@ public abstract class ContentProviderStore<T> {
     @NonNull
     protected final PublishSubject<Pair<T, Uri>> updateSubject = PublishSubject.create();
 
-    public ContentProviderStore(@NonNull ContentResolver contentResolver) {
+    protected ContentProviderStore(@NonNull ContentResolver contentResolver) {
         Preconditions.checkNotNull(contentResolver, "Content Resolver cannot be null.");
 
         this.contentResolver = contentResolver;
@@ -48,7 +57,7 @@ public abstract class ContentProviderStore<T> {
                 });
     }
 
-    protected static <T> void updateIfValueChanged(ContentProviderStore store, Pair<T, Uri> pair) {
+    private static <T> void updateIfValueChanged(ContentProviderStore store, Pair<T, Uri> pair) {
         boolean valuesEqual = false;
         final Cursor cursor = store.contentResolver.query(pair.second, store.getProjection(), null, null, null);
         final ContentValues newValues = store.getContentValuesForItem(pair.first);
@@ -131,7 +140,7 @@ public abstract class ContentProviderStore<T> {
     }
 
     @NonNull
-    abstract protected Uri getContentUri();
+    protected abstract Uri getContentUri();
 
     @NonNull
     protected abstract ContentObserver getContentObserver();

--- a/reark/src/main/java/io/reark/reark/data/store/SingleItemContentProviderStore.java
+++ b/reark/src/main/java/io/reark/reark/data/store/SingleItemContentProviderStore.java
@@ -47,7 +47,7 @@ public abstract class SingleItemContentProviderStore<T, U> extends ContentProvid
 
                 getOne(uri)
                         .doOnNext(item -> Log.v(TAG, format("onChange(%1s)", uri)))
-                        .map(it -> new StoreItem<>(uri, it))
+                        .map(item -> new StoreItem<>(uri, item))
                         .subscribe(subjectCache::onNext,
                                    error -> Log.e(TAG, "Cannot retrieve the item: " + uri, error));
             }
@@ -101,7 +101,7 @@ public abstract class SingleItemContentProviderStore<T, U> extends ContentProvid
         Preconditions.checkNotNull(id, "Id cannot be null.");
         Log.v(TAG, "getStream(" + id + ")");
 
-        return concat(getOne(id).filter(it -> it != null),
+        return concat(getOne(id).filter(item -> item != null),
                       getItemObservable(id))
                 .subscribeOn(AndroidSchedulers.mainThread());
     }
@@ -116,8 +116,8 @@ public abstract class SingleItemContentProviderStore<T, U> extends ContentProvid
     private Observable<T> getItemObservable(@NonNull U id) {
         Preconditions.checkNotNull(id, "Id cannot be null.");
         return subjectCache
-                .filter(it -> it.uri().equals(getUriForId(id)))
-                .doOnNext(it -> Log.v(TAG, "getItemObservable(" + it + ')'))
+                .filter(item -> item.uri().equals(getUriForId(id)))
+                .doOnNext(item -> Log.v(TAG, "getItemObservable(" + item + ')'))
                 .map(StoreItem::item);
     }
 

--- a/reark/src/main/java/io/reark/reark/data/store/SingleItemContentProviderStore.java
+++ b/reark/src/main/java/io/reark/reark/data/store/SingleItemContentProviderStore.java
@@ -76,7 +76,7 @@ public abstract class SingleItemContentProviderStore<T, U> extends ContentProvid
     public Observable<List<T>> get(@NonNull U id) {
         Preconditions.checkNotNull(id, "Id cannot be null.");
 
-        final Uri uri = getUriForKey(id);
+        final Uri uri = getUriForId(id);
         return get(uri);
     }
 
@@ -88,7 +88,7 @@ public abstract class SingleItemContentProviderStore<T, U> extends ContentProvid
     public Observable<T> getOne(@NonNull U id) {
         Preconditions.checkNotNull(id, "Id cannot be null.");
 
-        final Uri uri = getUriForKey(id);
+        final Uri uri = getUriForId(id);
         return getOne(uri);
     }
 
@@ -110,13 +110,13 @@ public abstract class SingleItemContentProviderStore<T, U> extends ContentProvid
      * Returns unique Uri for the given id in the content provider of this store.
      */
     @NonNull
-    public abstract Uri getUriForKey(@NonNull U id);
+    public abstract Uri getUriForId(@NonNull U id);
 
     @NonNull
     private Observable<T> getItemObservable(@NonNull U id) {
         Preconditions.checkNotNull(id, "Id cannot be null.");
         return subjectCache
-                .filter(it -> it.uri().equals(getUriForKey(id)))
+                .filter(it -> it.uri().equals(getUriForId(id)))
                 .doOnNext(it -> Log.v(TAG, "getItemObservable(" + it + ')'))
                 .map(StoreItem::item);
     }
@@ -125,7 +125,7 @@ public abstract class SingleItemContentProviderStore<T, U> extends ContentProvid
     private Uri getUriForItem(@NonNull T item) {
         Preconditions.checkNotNull(item, "Item cannot be null.");
 
-        return getUriForKey(getIdFor(item));
+        return getUriForId(getIdFor(item));
     }
 
     @NonNull

--- a/reark/src/main/java/io/reark/reark/data/store/SingleItemContentProviderStore.java
+++ b/reark/src/main/java/io/reark/reark/data/store/SingleItemContentProviderStore.java
@@ -16,7 +16,15 @@ import static java.lang.String.format;
 import static rx.Observable.concat;
 
 /**
- * Created by ttuo on 26/04/15.
+ * SingleItemContentProviderStore is a convenience implementation of ContentProviderStore for
+ * uniquely identifiable data types. The class provides a high-level API with id based get/put
+ * semantics and access to the content provider updates via a non-completing Observable.
+ *
+ * Data stores should extend this abstract class to provide type specific data serialization,
+ * comparison, id mapping, and content provider projection.
+ *
+ * @param <T> Type of the data this store contains.
+ * @param <U> Type of the id used in this store.
  */
 public abstract class SingleItemContentProviderStore<T, U> extends ContentProviderStore<T> {
 
@@ -46,12 +54,24 @@ public abstract class SingleItemContentProviderStore<T, U> extends ContentProvid
         };
     }
 
+    /**
+     * Inserts the given item to the store, or updates the store if an item with the same id
+     * already exists.
+     *
+     * Any open stream Observables for the item's id will emit this new value.
+     */
     public void put(@NonNull T item) {
         Preconditions.checkNotNull(item, "Item cannot be null.");
 
         put(item, getUriForItem(item));
     }
 
+    /**
+     * Returns a completing Observable of all items matching the id.
+     *
+     * This method can for example be used to request all the contents of this store
+     * by providing an empty id.
+     */
     @NonNull
     public Observable<List<T>> get(@NonNull U id) {
         Preconditions.checkNotNull(id, "Id cannot be null.");
@@ -60,6 +80,10 @@ public abstract class SingleItemContentProviderStore<T, U> extends ContentProvid
         return get(uri);
     }
 
+    /**
+     * Returns a completing Observable that either emits the first existing item in the store
+     * matching the id, or emits null if the store does not contain the requested id.
+     */
     @NonNull
     public Observable<T> getOne(@NonNull U id) {
         Preconditions.checkNotNull(id, "Id cannot be null.");
@@ -68,6 +92,10 @@ public abstract class SingleItemContentProviderStore<T, U> extends ContentProvid
         return getOne(uri);
     }
 
+    /**
+     * Returns a non-completing Observable of items matching the id. The Observable emits the first
+     * matching item existing in the store, if any, and continues to emit all new matching items.
+     */
     @NonNull
     public Observable<T> getStream(@NonNull U id) {
         Preconditions.checkNotNull(id, "Id cannot be null.");
@@ -77,6 +105,12 @@ public abstract class SingleItemContentProviderStore<T, U> extends ContentProvid
                       getItemObservable(id))
                 .subscribeOn(AndroidSchedulers.mainThread());
     }
+
+    /**
+     * Returns unique Uri for the given id in the content provider of this store.
+     */
+    @NonNull
+    public abstract Uri getUriForKey(@NonNull U id);
 
     @NonNull
     private Observable<T> getItemObservable(@NonNull U id) {
@@ -93,9 +127,6 @@ public abstract class SingleItemContentProviderStore<T, U> extends ContentProvid
 
         return getUriForKey(getIdFor(item));
     }
-
-    @NonNull
-    public abstract Uri getUriForKey(@NonNull U id);
 
     @NonNull
     protected abstract U getIdFor(@NonNull T item);


### PR DESCRIPTION
Previous store API gave us get/query and put/insert methods. This change tries to bring consistency by using the get/put names for all methods. Also adds a new call for getting observable list of all results, and some basic documentation for the content provider store classes.