### PR TITLE
Replaced Map of Subjects with a single subject

### DIFF
--- a/reark/src/main/java/io/reark/reark/data/store/ContentProviderStore.java
+++ b/reark/src/main/java/io/reark/reark/data/store/ContentProviderStore.java
@@ -35,6 +35,8 @@ public abstract class ContentProviderStore<T> {
     protected final PublishSubject<Pair<T, Uri>> updateSubject = PublishSubject.create();
 
     public ContentProviderStore(@NonNull ContentResolver contentResolver) {
+        Preconditions.checkNotNull(contentResolver, "Content Resolver cannot be null.");
+
         this.contentResolver = contentResolver;
         this.contentResolver.registerContentObserver(getContentUri(), true, contentObserver);
 

--- a/reark/src/main/java/io/reark/reark/data/store/SingleItemContentProviderStore.java
+++ b/reark/src/main/java/io/reark/reark/data/store/SingleItemContentProviderStore.java
@@ -38,7 +38,8 @@ abstract public class SingleItemContentProviderStore<T, U> extends ContentProvid
                 queryOne(uri)
                         .doOnNext(item -> Log.v(TAG, "onChange(" + uri + ')'))
                         .map(it -> new StoreItem<>(uri, it))
-                        .subscribe(subjectCache);
+                        .subscribe(subjectCache::onNext,
+                                   error -> Log.e(TAG, "Cannot retrieve the item: " + uri, error));
             }
         };
     }

--- a/reark/src/main/java/io/reark/reark/data/store/SingleItemContentProviderStore.java
+++ b/reark/src/main/java/io/reark/reark/data/store/SingleItemContentProviderStore.java
@@ -11,19 +11,20 @@ import rx.Observable;
 import rx.android.schedulers.AndroidSchedulers;
 import rx.subjects.PublishSubject;
 
+import static java.lang.String.format;
 import static rx.Observable.concat;
 
 /**
  * Created by ttuo on 26/04/15.
  */
-abstract public class SingleItemContentProviderStore<T, U> extends ContentProviderStore<T> {
+public abstract class SingleItemContentProviderStore<T, U> extends ContentProviderStore<T> {
 
     private static final String TAG = SingleItemContentProviderStore.class.getSimpleName();
 
     @NonNull
-    final private PublishSubject<StoreItem<T>> subjectCache = PublishSubject.create();
+    private final PublishSubject<StoreItem<T>> subjectCache = PublishSubject.create();
 
-    public SingleItemContentProviderStore(@NonNull ContentResolver contentResolver) {
+    protected SingleItemContentProviderStore(@NonNull ContentResolver contentResolver) {
         super(contentResolver);
     }
 
@@ -36,7 +37,7 @@ abstract public class SingleItemContentProviderStore<T, U> extends ContentProvid
                 super.onChange(selfChange, uri);
 
                 queryOne(uri)
-                        .doOnNext(item -> Log.v(TAG, "onChange(" + uri + ')'))
+                        .doOnNext(item -> Log.v(TAG, format("onChange(%1s)", uri)))
                         .map(it -> new StoreItem<>(uri, it))
                         .subscribe(subjectCache::onNext,
                                    error -> Log.e(TAG, "Cannot retrieve the item: " + uri, error));
@@ -86,9 +87,9 @@ abstract public class SingleItemContentProviderStore<T, U> extends ContentProvid
     }
 
     @NonNull
-    abstract public Uri getUriForKey(@NonNull U id);
+    public abstract Uri getUriForKey(@NonNull U id);
 
     @NonNull
-    abstract protected U getIdFor(@NonNull T item);
+    protected abstract U getIdFor(@NonNull T item);
 
 }

--- a/reark/src/main/java/io/reark/reark/data/store/SingleItemContentProviderStore.java
+++ b/reark/src/main/java/io/reark/reark/data/store/SingleItemContentProviderStore.java
@@ -5,41 +5,40 @@ import android.database.ContentObserver;
 import android.net.Uri;
 import android.support.annotation.NonNull;
 
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-
 import io.reark.reark.utils.Log;
 import io.reark.reark.utils.Preconditions;
 import rx.Observable;
 import rx.android.schedulers.AndroidSchedulers;
 import rx.subjects.PublishSubject;
-import rx.subjects.Subject;
+
+import static rx.Observable.concat;
 
 /**
  * Created by ttuo on 26/04/15.
  */
 abstract public class SingleItemContentProviderStore<T, U> extends ContentProviderStore<T> {
+
     private static final String TAG = SingleItemContentProviderStore.class.getSimpleName();
 
-    final private ConcurrentMap<Uri, Subject<T, T>> subjectMap = new ConcurrentHashMap<>();
+    @NonNull
+    final private PublishSubject<StoreItem<T>> subjectCache = PublishSubject.create();
 
     public SingleItemContentProviderStore(@NonNull ContentResolver contentResolver) {
         super(contentResolver);
-        Preconditions.checkNotNull(contentResolver, "Content Resolver cannot be null.");
     }
 
     @NonNull
     @Override
     protected ContentObserver getContentObserver() {
-        return new ContentObserver(createHandler(this.getClass().getSimpleName())) {
+        return new ContentObserver(createHandler(getClass().getSimpleName())) {
             @Override
             public void onChange(boolean selfChange, Uri uri) {
                 super.onChange(selfChange, uri);
-                Log.v(TAG, "onChange(" + uri + ")");
 
-                if (subjectMap.containsKey(uri)) {
-                    queryOne(uri).subscribe(t -> subjectMap.get(uri).onNext(t));
-                }
+                queryOne(uri)
+                        .doOnNext(item -> Log.v(TAG, "onChange(" + uri + ')'))
+                        .map(it -> new StoreItem<>(uri, it))
+                        .subscribe(subjectCache);
             }
         };
     }
@@ -56,40 +55,32 @@ abstract public class SingleItemContentProviderStore<T, U> extends ContentProvid
 
         Log.v(TAG, "getStream(" + id + ")");
 
-        return query(id)
-                .flatMap(item -> {
-                    final Observable<T> observable = lazyGetSubject(id);
-                    if (item != null) {
-                        Log.v(TAG, "Found existing item for id=" + id);
-                        return observable.startWith(item);
-                    }
-                    return observable;
-                })
+        return concat(query(id).filter(it -> it != null),
+                      getItemObservable(id))
                 .subscribeOn(AndroidSchedulers.mainThread());
-
     }
 
     @NonNull
-    private Observable<T> lazyGetSubject(@NonNull U id) {
+    private Observable<T> getItemObservable(@NonNull U id) {
         Preconditions.checkNotNull(id, "Id cannot be null.");
 
-        Log.v(TAG, "lazyGetSubject(" + id + ")");
-        final Uri uri = getUriForKey(id);
-        subjectMap.putIfAbsent(uri, PublishSubject.<T>create());
-        return subjectMap.get(uri);
+        return subjectCache
+                .filter(it -> it.uri().equals(getUriForKey(id)))
+                .doOnNext(it -> Log.v(TAG, "getItemObservable(" + it + ')'))
+                .map(StoreItem::item);
     }
 
     @NonNull
     protected Observable<T> query(@NonNull U id) {
         Preconditions.checkNotNull(id, "Id cannot be null.");
 
-        final Uri uri = getUriForKey(id);
-        return queryOne(uri);
+        return queryOne(getUriForKey(id));
     }
 
     @NonNull
     private Uri getUriForItem(@NonNull T item) {
         Preconditions.checkNotNull(item, "Item cannot be null.");
+
         return getUriForKey(getIdFor(item));
     }
 
@@ -98,4 +89,5 @@ abstract public class SingleItemContentProviderStore<T, U> extends ContentProvid
 
     @NonNull
     abstract protected U getIdFor(@NonNull T item);
+
 }

--- a/reark/src/main/java/io/reark/reark/data/store/StoreItem.java
+++ b/reark/src/main/java/io/reark/reark/data/store/StoreItem.java
@@ -1,0 +1,68 @@
+package io.reark.reark.data.store;
+
+import android.net.Uri;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import io.reark.reark.utils.Preconditions;
+
+/**
+ * Created by Pawel Polanski on 12/28/15.
+ */
+class StoreItem<T> {
+
+    @NonNull
+    private final Uri uri;
+
+    @Nullable
+    private final T item;
+
+    StoreItem(@NonNull final Uri uri, @Nullable final T item) {
+        Preconditions.checkNotNull(uri, "uri cannot be null.");
+
+        this.uri = uri;
+        this.item = item;
+    }
+
+    @NonNull
+    public Uri uri() {
+        return uri;
+    }
+
+    @Nullable
+    public T item() {
+        return item;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof StoreItem)) {
+            return false;
+        }
+
+        final StoreItem<?> storeItem = (StoreItem<?>) o;
+
+        return uri.equals(storeItem.uri)
+               && (item != null ? item.equals(storeItem.item) : storeItem.item == null);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = uri.hashCode();
+        result = 31 * result + (item != null ? item.hashCode() : 0);
+        return result;
+    }
+
+
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer("StoreItem{");
+        sb.append("uri=").append(uri);
+        sb.append(", item=").append(item);
+        sb.append('}');
+        return sb.toString();
+    }
+}


### PR DESCRIPTION
Map of subjects had an issue with a race condition.
Additionally already created subjects were never cleaned.
Replacing them with a single subject ensures that when
a subscriber finishes the subscrition is being disposed.
Keeping all the logic handling in a single monad makes sure
that all race conditions are handeled properly.