### PR TITLE
Add FETCHING_COMPLETED as a status for DataStreamNotification

### DIFF
--- a/reark/src/main/java/io/reark/reark/data/DataStreamNotification.java
+++ b/reark/src/main/java/io/reark/reark/data/DataStreamNotification.java
@@ -11,7 +11,10 @@ import io.reark.reark.utils.Preconditions;
 public class DataStreamNotification<T> {
 
     private enum Type {
-        FETCHING_START, FETCHING_ERROR, ON_NEXT
+        FETCHING_START,
+        FETCHING_COMPLETED,
+        FETCHING_ERROR,
+        ON_NEXT
     }
 
     @NonNull
@@ -43,6 +46,11 @@ public class DataStreamNotification<T> {
     }
 
     @NonNull
+    public static<T> DataStreamNotification<T> fetchingCompleted() {
+        return new DataStreamNotification<>(Type.FETCHING_COMPLETED, null, null);
+    }
+
+    @NonNull
     public static<T> DataStreamNotification<T> fetchingError() {
         return new DataStreamNotification<>(Type.FETCHING_ERROR, null, null);
     }
@@ -53,6 +61,10 @@ public class DataStreamNotification<T> {
 
     public boolean isOnNext() {
         return type.equals(Type.ON_NEXT);
+    }
+
+    public boolean isFetchingCompleted() {
+        return type.equals(Type.FETCHING_COMPLETED);
     }
 
     public boolean isFetchingError() {

--- a/reark/src/main/java/io/reark/reark/data/utils/DataLayerUtils.java
+++ b/reark/src/main/java/io/reark/reark/data/utils/DataLayerUtils.java
@@ -12,32 +12,34 @@ import rx.functions.Func1;
  */
 public class DataLayerUtils {
     private DataLayerUtils() {
-
     }
 
     @NonNull
     public static<T> Observable<DataStreamNotification<T>> createDataStreamNotificationObservable(
             @NonNull Observable<NetworkRequestStatus> networkRequestStatusObservable,
             @NonNull Observable<T> valueObservable) {
+
         final Observable<DataStreamNotification<T>> networkStatusStream =
                 networkRequestStatusObservable
-                        .filter(networkRequestStatus ->
-                                !networkRequestStatus.isCompleted())
                         .map(new Func1<NetworkRequestStatus, DataStreamNotification<T>>() {
                             @Override
                             public DataStreamNotification<T> call(NetworkRequestStatus networkRequestStatus) {
-                                if (networkRequestStatus.isError()) {
-                                    return DataStreamNotification.fetchingError();
-                                } else if (networkRequestStatus.isOngoing()) {
+                                if (networkRequestStatus.isOngoing()) {
                                     return DataStreamNotification.fetchingStart();
+                                } else if (networkRequestStatus.isCompleted()) {
+                                    return DataStreamNotification.fetchingCompleted();
+                                } else if (networkRequestStatus.isError()) {
+                                    return DataStreamNotification.fetchingError();
                                 } else {
                                     return null;
                                 }
                             }
                         })
                         .filter(dataStreamNotification -> dataStreamNotification != null);
+
         final Observable<DataStreamNotification<T>> valueStream =
                 valueObservable.map(DataStreamNotification::onNext);
+
         return Observable.merge(networkStatusStream, valueStream);
     }
 }


### PR DESCRIPTION
The problem with no completed status is that the DataStreamNotification status stream is completely separated from the value stream. As a consequence, there is no guarantee that a completed query results in update in value stream. This could happen e.g. in case a newly fetched value is identical with old value already in the stream.

Solution is to handle status stream onCompleted and value stream onNext separately.