### PR TITLE
Use debounce instead of throttleLast to avoid constant searching

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Application Structure
 To use the app start writing a search in the text box of at least 3 characters. This will trigger a network request and the five first results of which will be shown as a list. The input also throttled in a way that makes it trigger when the user stops typing. This is a very good basic example of Rx streams.
 
 `.filter((string) -> string.length() > 2)
-.throttleLast(500, TimeUnit.MILLISECONDS)`
+.debounce(500, TimeUnit.MILLISECONDS)`
 
 
 The Basic Data Flow

--- a/app/src/main/java/io/reark/rxgithubapp/view/RepositoriesView.java
+++ b/app/src/main/java/io/reark/rxgithubapp/view/RepositoriesView.java
@@ -12,6 +12,7 @@ import android.widget.TextView;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import io.reark.reark.utils.Preconditions;
 import io.reark.reark.utils.RxViewBinder;
@@ -75,7 +76,6 @@ public class RepositoriesView extends FrameLayout {
 
         String networkStatusText = "";
         switch (networkRequestStatus) {
-
             case LOADING:
                 networkStatusText = "Loading..";
                 break;

--- a/app/src/main/java/io/reark/rxgithubapp/view/RepositoriesView.java
+++ b/app/src/main/java/io/reark/rxgithubapp/view/RepositoriesView.java
@@ -12,7 +12,6 @@ import android.widget.TextView;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 import io.reark.reark.utils.Preconditions;
 import io.reark.reark.utils.RxViewBinder;
@@ -74,19 +73,19 @@ public class RepositoriesView extends FrameLayout {
     private void setNetworkRequestStatus(@NonNull ProgressStatus networkRequestStatus) {
         Preconditions.checkNotNull(networkRequestStatus, "Network Request Status cannot be null.");
 
-        String networkStatusText = "";
+        setNetworkRequestStatusText(getLoadingStatusString(networkRequestStatus));
+    }
+
+    private String getLoadingStatusString(ProgressStatus networkRequestStatus) {
         switch (networkRequestStatus) {
             case LOADING:
-                networkStatusText = "Loading..";
-                break;
+                return "Loading..";
             case ERROR:
-                networkStatusText = "Error occurred";
-                break;
+                return "Error occurred";
             case IDLE:
-                networkStatusText = "";
-                break;
+            default:
+                return "";
         }
-        setNetworkRequestStatusText(networkStatusText);
     }
 
     private void setNetworkRequestStatusText(@NonNull String networkRequestStatusText) {

--- a/app/src/main/java/io/reark/rxgithubapp/viewmodels/RepositoriesViewModel.java
+++ b/app/src/main/java/io/reark/rxgithubapp/viewmodels/RepositoriesViewModel.java
@@ -103,7 +103,7 @@ public class RepositoriesViewModel extends AbstractViewModel {
         ConnectableObservable<DataStreamNotification<GitHubRepositorySearch>> repositorySearchSource =
                 searchString
                           .filter((string) -> string.length() > 2)
-                          .throttleLast(500, TimeUnit.MILLISECONDS)
+                          .debounce(1000, TimeUnit.MILLISECONDS)
                           .switchMap(getGitHubRepositorySearch::call)
                           .publish();
 

--- a/app/src/main/java/io/reark/rxgithubapp/viewmodels/RepositoriesViewModel.java
+++ b/app/src/main/java/io/reark/rxgithubapp/viewmodels/RepositoriesViewModel.java
@@ -31,6 +31,7 @@ public class RepositoriesViewModel extends AbstractViewModel {
     }
 
     private static final int MAX_REPOSITORIES_DISPLAYED = 5;
+    private static final int SEARCH_INPUT_DELAY = 500;
 
     @NonNull
     private final DataLayer.GetGitHubRepositorySearch getGitHubRepositorySearch;
@@ -103,7 +104,7 @@ public class RepositoriesViewModel extends AbstractViewModel {
         ConnectableObservable<DataStreamNotification<GitHubRepositorySearch>> repositorySearchSource =
                 searchString
                           .filter((string) -> string.length() > 2)
-                          .debounce(1000, TimeUnit.MILLISECONDS)
+                          .debounce(SEARCH_INPUT_DELAY, TimeUnit.MILLISECONDS)
                           .switchMap(getGitHubRepositorySearch::call)
                           .publish();
 


### PR DESCRIPTION
Debounce restarts timer on each change, whereas throttleLast is sampling on fixed timer. The sampling causes search to be restarted constantly, which quickly uses up our API quota when testing.