### PR TITLE
Add LICENSE.md and source file license headers

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,23 @@
+The MIT License
+
+Copyright (c) 2013-2016 reark project contributors
+
+https://github.com/reark/reark/graphs/contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -184,4 +184,26 @@ The Fetchers run exclusively in the NetworkService, making them hidden from the 
 License
 =======
 
-The code found here is licensed under the [MIT License](http://creativecommons.org/licenses/MIT/)
+    The MIT License
+
+    Copyright (c) 2013-2016 reark project contributors
+
+    https://github.com/reark/reark/graphs/contributors
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.

--- a/app/src/androidTest/java/io/reark/rxgithubapp/activities/ChooseRepositoryActivityTest.java
+++ b/app/src/androidTest/java/io/reark/rxgithubapp/activities/ChooseRepositoryActivityTest.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.rxgithubapp.activities;
 
 import android.support.test.InstrumentationRegistry;

--- a/app/src/androidTest/java/io/reark/rxgithubapp/activities/ChooseRepositoryActivityTest.java
+++ b/app/src/androidTest/java/io/reark/rxgithubapp/activities/ChooseRepositoryActivityTest.java
@@ -47,9 +47,6 @@ import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static android.support.test.espresso.matcher.ViewMatchers.withText;
 
-/**
- * Created by Pawel Polanski on 5/27/15.
- */
 @LargeTest
 @RunWith(AndroidJUnit4.class)
 public class ChooseRepositoryActivityTest {

--- a/app/src/androidTest/java/io/reark/rxgithubapp/activities/MainActivityTest.java
+++ b/app/src/androidTest/java/io/reark/rxgithubapp/activities/MainActivityTest.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.rxgithubapp.activities;
 
 import android.support.test.InstrumentationRegistry;

--- a/app/src/androidTest/java/io/reark/rxgithubapp/activities/MainActivityTest.java
+++ b/app/src/androidTest/java/io/reark/rxgithubapp/activities/MainActivityTest.java
@@ -45,9 +45,7 @@ import static android.support.test.espresso.assertion.ViewAssertions.matches;
 import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static android.support.test.espresso.matcher.ViewMatchers.withText;
-/**
- * Created by Pawel Polanski on 4/27/15.
- */
+
 @LargeTest
 @RunWith(AndroidJUnit4.class)
 public class MainActivityTest {

--- a/app/src/androidTest/java/io/reark/rxgithubapp/activities/utils/SystemAnimations.java
+++ b/app/src/androidTest/java/io/reark/rxgithubapp/activities/utils/SystemAnimations.java
@@ -1,8 +1,5 @@
 package io.reark.rxgithubapp.activities.utils;
 
-/**
- * Created by Pawel Polanski on 5/22/15.
- */
 
 import android.content.Context;
 import android.content.pm.PackageManager;

--- a/app/src/androidTest/java/io/reark/rxgithubapp/activities/utils/SystemAnimations.java
+++ b/app/src/androidTest/java/io/reark/rxgithubapp/activities/utils/SystemAnimations.java
@@ -1,6 +1,5 @@
 package io.reark.rxgithubapp.activities.utils;
 
-
 import android.content.Context;
 import android.content.pm.PackageManager;
 import android.os.IBinder;

--- a/app/src/debug/java/io/reark/rxgithubapp/injections/DebugInstrumentationModule.java
+++ b/app/src/debug/java/io/reark/rxgithubapp/injections/DebugInstrumentationModule.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.rxgithubapp.injections;
 
 import android.app.Application;

--- a/app/src/debug/java/io/reark/rxgithubapp/injections/DebugInstrumentationModule.java
+++ b/app/src/debug/java/io/reark/rxgithubapp/injections/DebugInstrumentationModule.java
@@ -43,9 +43,6 @@ import io.reark.rxgithubapp.utils.LeakCanaryTracing;
 import io.reark.rxgithubapp.utils.LeakTracing;
 import io.reark.rxgithubapp.utils.StethoInstrumentation;
 
-/**
- * Created by Pawel Polanski on 4/24/15.
- */
 @Module
 public class DebugInstrumentationModule {
 

--- a/app/src/debug/java/io/reark/rxgithubapp/injections/Graph.java
+++ b/app/src/debug/java/io/reark/rxgithubapp/injections/Graph.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.rxgithubapp.injections;
 
 import android.app.Application;

--- a/app/src/debug/java/io/reark/rxgithubapp/injections/Graph.java
+++ b/app/src/debug/java/io/reark/rxgithubapp/injections/Graph.java
@@ -41,9 +41,6 @@ import io.reark.rxgithubapp.viewmodels.RepositoryViewModel;
 import io.reark.rxgithubapp.viewmodels.ViewModelModule;
 import io.reark.rxgithubapp.widget.WidgetService;
 
-/**
- * Created by pt2121 on 2/20/15.
- */
 @Singleton
 @Component(modules = {ApplicationModule.class, DataStoreModule.class, ViewModelModule.class,
                       DebugInstrumentationModule.class})

--- a/app/src/debug/java/io/reark/rxgithubapp/utils/DebugApplicationInstrumentation.java
+++ b/app/src/debug/java/io/reark/rxgithubapp/utils/DebugApplicationInstrumentation.java
@@ -29,9 +29,7 @@ import android.support.annotation.NonNull;
 
 import io.reark.reark.utils.Preconditions;
 
-public class DebugApplicationInstrumentation implements ApplicationInstrumentation
-{
-
+public class DebugApplicationInstrumentation implements ApplicationInstrumentation {
     @NonNull
     private final LeakTracing leakTracing;
 
@@ -59,5 +57,4 @@ public class DebugApplicationInstrumentation implements ApplicationInstrumentati
     public LeakTracing getLeakTracing() {
         return leakTracing;
     }
-
 }

--- a/app/src/debug/java/io/reark/rxgithubapp/utils/DebugApplicationInstrumentation.java
+++ b/app/src/debug/java/io/reark/rxgithubapp/utils/DebugApplicationInstrumentation.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.rxgithubapp.utils;
 
 import android.support.annotation.NonNull;

--- a/app/src/debug/java/io/reark/rxgithubapp/utils/LeakCanaryTracing.java
+++ b/app/src/debug/java/io/reark/rxgithubapp/utils/LeakCanaryTracing.java
@@ -30,9 +30,6 @@ import android.app.Application;
 import com.squareup.leakcanary.LeakCanary;
 import com.squareup.leakcanary.RefWatcher;
 
-/**
- * Created by Pawel Polanski on 5/9/15.
- */
 public class LeakCanaryTracing implements LeakTracing {
 
     private RefWatcher refWatcher;

--- a/app/src/debug/java/io/reark/rxgithubapp/utils/LeakCanaryTracing.java
+++ b/app/src/debug/java/io/reark/rxgithubapp/utils/LeakCanaryTracing.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.rxgithubapp.utils;
 
 import android.app.Application;

--- a/app/src/debug/java/io/reark/rxgithubapp/utils/StethoInstrumentation.java
+++ b/app/src/debug/java/io/reark/rxgithubapp/utils/StethoInstrumentation.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.rxgithubapp.utils;
 
 import android.content.Context;

--- a/app/src/debug/java/io/reark/rxgithubapp/utils/StethoInstrumentation.java
+++ b/app/src/debug/java/io/reark/rxgithubapp/utils/StethoInstrumentation.java
@@ -56,7 +56,6 @@ public class StethoInstrumentation implements NetworkInstrumentation<OkHttpClien
         this.interceptor = interceptor;
     }
 
-
     @Override
     public void init() {
         initStetho();

--- a/app/src/main/java/io/reark/rxgithubapp/RxGitHubApp.java
+++ b/app/src/main/java/io/reark/rxgithubapp/RxGitHubApp.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.rxgithubapp;
 
 import android.app.Application;

--- a/app/src/main/java/io/reark/rxgithubapp/RxGitHubApp.java
+++ b/app/src/main/java/io/reark/rxgithubapp/RxGitHubApp.java
@@ -33,9 +33,6 @@ import javax.inject.Inject;
 import io.reark.rxgithubapp.injections.Graph;
 import io.reark.rxgithubapp.utils.ApplicationInstrumentation;
 
-/**
- * Created by pt2121 on 2/20/15.
- */
 public class RxGitHubApp extends Application {
 
     private static RxGitHubApp instance;

--- a/app/src/main/java/io/reark/rxgithubapp/activities/ChooseRepositoryActivity.java
+++ b/app/src/main/java/io/reark/rxgithubapp/activities/ChooseRepositoryActivity.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.rxgithubapp.activities;
 
 import android.content.Intent;

--- a/app/src/main/java/io/reark/rxgithubapp/activities/ChooseRepositoryActivity.java
+++ b/app/src/main/java/io/reark/rxgithubapp/activities/ChooseRepositoryActivity.java
@@ -32,7 +32,6 @@ import android.support.v7.app.AppCompatActivity;
 import io.reark.rxgithubapp.R;
 import io.reark.rxgithubapp.fragments.RepositoriesFragment;
 
-
 public class ChooseRepositoryActivity extends AppCompatActivity {
     private static final String TAG = ChooseRepositoryActivity.class.getSimpleName();
 

--- a/app/src/main/java/io/reark/rxgithubapp/activities/MainActivity.java
+++ b/app/src/main/java/io/reark/rxgithubapp/activities/MainActivity.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.rxgithubapp.activities;
 
 import android.content.Intent;

--- a/app/src/main/java/io/reark/rxgithubapp/activities/MainActivity.java
+++ b/app/src/main/java/io/reark/rxgithubapp/activities/MainActivity.java
@@ -38,7 +38,6 @@ import io.reark.rxgithubapp.data.DataLayer;
 import io.reark.rxgithubapp.fragments.RepositoryFragment;
 import io.reark.rxgithubapp.pojo.UserSettings;
 
-
 public class MainActivity extends AppCompatActivity {
     private static final String TAG = MainActivity.class.getSimpleName();
 

--- a/app/src/main/java/io/reark/rxgithubapp/data/DataLayer.java
+++ b/app/src/main/java/io/reark/rxgithubapp/data/DataLayer.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.rxgithubapp.data;
 
 import android.content.Context;

--- a/app/src/main/java/io/reark/rxgithubapp/data/DataLayer.java
+++ b/app/src/main/java/io/reark/rxgithubapp/data/DataLayer.java
@@ -45,10 +45,6 @@ import io.reark.rxgithubapp.pojo.GitHubRepositorySearch;
 import io.reark.rxgithubapp.pojo.UserSettings;
 import rx.Observable;
 
-
-/**
- * Created by ttuo on 19/03/14.
- */
 public class DataLayer extends DataLayerBase {
     private static final String TAG = DataLayer.class.getSimpleName();
     private final Context context;

--- a/app/src/main/java/io/reark/rxgithubapp/data/DataLayerBase.java
+++ b/app/src/main/java/io/reark/rxgithubapp/data/DataLayerBase.java
@@ -32,9 +32,6 @@ import io.reark.rxgithubapp.data.stores.GitHubRepositorySearchStore;
 import io.reark.rxgithubapp.data.stores.GitHubRepositoryStore;
 import io.reark.rxgithubapp.data.stores.NetworkRequestStatusStore;
 
-/**
- * Created by ttuo on 16/04/15.
- */
 abstract public class DataLayerBase {
     protected final NetworkRequestStatusStore networkRequestStatusStore;
     protected final GitHubRepositoryStore gitHubRepositoryStore;

--- a/app/src/main/java/io/reark/rxgithubapp/data/DataLayerBase.java
+++ b/app/src/main/java/io/reark/rxgithubapp/data/DataLayerBase.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.rxgithubapp.data;
 
 import android.support.annotation.NonNull;

--- a/app/src/main/java/io/reark/rxgithubapp/data/DataStoreModule.java
+++ b/app/src/main/java/io/reark/rxgithubapp/data/DataStoreModule.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.rxgithubapp.data;
 
 import android.content.Context;

--- a/app/src/main/java/io/reark/rxgithubapp/data/DataStoreModule.java
+++ b/app/src/main/java/io/reark/rxgithubapp/data/DataStoreModule.java
@@ -41,9 +41,6 @@ import io.reark.rxgithubapp.injections.ForApplication;
 import io.reark.rxgithubapp.network.ServiceDataLayer;
 import io.reark.rxgithubapp.network.fetchers.FetcherModule;
 
-/**
- * Created by pt2121 on 2/20/15.
- */
 @Module(includes = { FetcherModule.class, StoreModule.class })
 public final class DataStoreModule {
 

--- a/app/src/main/java/io/reark/rxgithubapp/data/schematicProvider/GitHubDatabase.java
+++ b/app/src/main/java/io/reark/rxgithubapp/data/schematicProvider/GitHubDatabase.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.rxgithubapp.data.schematicProvider;
 
 import net.simonvt.schematic.annotation.Database;

--- a/app/src/main/java/io/reark/rxgithubapp/data/schematicProvider/GitHubDatabase.java
+++ b/app/src/main/java/io/reark/rxgithubapp/data/schematicProvider/GitHubDatabase.java
@@ -28,9 +28,6 @@ package io.reark.rxgithubapp.data.schematicProvider;
 import net.simonvt.schematic.annotation.Database;
 import net.simonvt.schematic.annotation.Table;
 
-/**
- * Created by ttuo on 14/07/15.
- */
 @Database(version = GitHubDatabase.VERSION)
 public final class GitHubDatabase {
     public static final int VERSION = 1;

--- a/app/src/main/java/io/reark/rxgithubapp/data/schematicProvider/GitHubProvider.java
+++ b/app/src/main/java/io/reark/rxgithubapp/data/schematicProvider/GitHubProvider.java
@@ -35,9 +35,6 @@ import net.simonvt.schematic.annotation.TableEndpoint;
 
 import io.reark.reark.utils.Preconditions;
 
-/**
- * Created by ttuo on 14/07/15.
- */
 @ContentProvider(authority = GitHubProvider.AUTHORITY, database = GitHubDatabase.class)
 public class GitHubProvider {
     public static final String AUTHORITY = "io.reark.rxgithubapp.data.schematicProvider.GitHubProvider";

--- a/app/src/main/java/io/reark/rxgithubapp/data/schematicProvider/GitHubProvider.java
+++ b/app/src/main/java/io/reark/rxgithubapp/data/schematicProvider/GitHubProvider.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.rxgithubapp.data.schematicProvider;
 
 import android.net.Uri;

--- a/app/src/main/java/io/reark/rxgithubapp/data/schematicProvider/GitHubRepositoryColumns.java
+++ b/app/src/main/java/io/reark/rxgithubapp/data/schematicProvider/GitHubRepositoryColumns.java
@@ -25,8 +25,5 @@
  */
 package io.reark.rxgithubapp.data.schematicProvider;
 
-/**
- * Created by ttuo on 14/07/15.
- */
 public interface GitHubRepositoryColumns extends JsonIdColumns {
 }

--- a/app/src/main/java/io/reark/rxgithubapp/data/schematicProvider/GitHubRepositoryColumns.java
+++ b/app/src/main/java/io/reark/rxgithubapp/data/schematicProvider/GitHubRepositoryColumns.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.rxgithubapp.data.schematicProvider;
 
 /**

--- a/app/src/main/java/io/reark/rxgithubapp/data/schematicProvider/GitHubRepositorySearchColumns.java
+++ b/app/src/main/java/io/reark/rxgithubapp/data/schematicProvider/GitHubRepositorySearchColumns.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.rxgithubapp.data.schematicProvider;
 
 import net.simonvt.schematic.annotation.DataType;

--- a/app/src/main/java/io/reark/rxgithubapp/data/schematicProvider/GitHubRepositorySearchColumns.java
+++ b/app/src/main/java/io/reark/rxgithubapp/data/schematicProvider/GitHubRepositorySearchColumns.java
@@ -28,9 +28,6 @@ package io.reark.rxgithubapp.data.schematicProvider;
 import net.simonvt.schematic.annotation.DataType;
 import net.simonvt.schematic.annotation.PrimaryKey;
 
-/**
- * Created by ttuo on 14/07/15.
- */
 public interface GitHubRepositorySearchColumns {
     @DataType(DataType.Type.TEXT) @PrimaryKey String SEARCH = "id";
     @DataType(DataType.Type.TEXT) String JSON = "json";

--- a/app/src/main/java/io/reark/rxgithubapp/data/schematicProvider/JsonIdColumns.java
+++ b/app/src/main/java/io/reark/rxgithubapp/data/schematicProvider/JsonIdColumns.java
@@ -28,9 +28,6 @@ package io.reark.rxgithubapp.data.schematicProvider;
 import net.simonvt.schematic.annotation.DataType;
 import net.simonvt.schematic.annotation.PrimaryKey;
 
-/**
- * Created by ttuo on 14/07/15.
- */
 public interface JsonIdColumns {
     @DataType(DataType.Type.INTEGER) @PrimaryKey String ID = "id";
     @DataType(DataType.Type.TEXT) String JSON = "json";

--- a/app/src/main/java/io/reark/rxgithubapp/data/schematicProvider/JsonIdColumns.java
+++ b/app/src/main/java/io/reark/rxgithubapp/data/schematicProvider/JsonIdColumns.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.rxgithubapp.data.schematicProvider;
 
 import net.simonvt.schematic.annotation.DataType;

--- a/app/src/main/java/io/reark/rxgithubapp/data/schematicProvider/NetworkRequestStatusColumns.java
+++ b/app/src/main/java/io/reark/rxgithubapp/data/schematicProvider/NetworkRequestStatusColumns.java
@@ -25,8 +25,5 @@
  */
 package io.reark.rxgithubapp.data.schematicProvider;
 
-/**
- * Created by ttuo on 14/07/15.
- */
 public interface NetworkRequestStatusColumns extends JsonIdColumns {
 }

--- a/app/src/main/java/io/reark/rxgithubapp/data/schematicProvider/NetworkRequestStatusColumns.java
+++ b/app/src/main/java/io/reark/rxgithubapp/data/schematicProvider/NetworkRequestStatusColumns.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.rxgithubapp.data.schematicProvider;
 
 /**

--- a/app/src/main/java/io/reark/rxgithubapp/data/schematicProvider/UserSettingsColumns.java
+++ b/app/src/main/java/io/reark/rxgithubapp/data/schematicProvider/UserSettingsColumns.java
@@ -25,8 +25,5 @@
  */
 package io.reark.rxgithubapp.data.schematicProvider;
 
-/**
- * Created by ttuo on 14/07/15.
- */
 public interface UserSettingsColumns extends JsonIdColumns {
 }

--- a/app/src/main/java/io/reark/rxgithubapp/data/schematicProvider/UserSettingsColumns.java
+++ b/app/src/main/java/io/reark/rxgithubapp/data/schematicProvider/UserSettingsColumns.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.rxgithubapp.data.schematicProvider;
 
 /**

--- a/app/src/main/java/io/reark/rxgithubapp/data/stores/GitHubRepositorySearchStore.java
+++ b/app/src/main/java/io/reark/rxgithubapp/data/stores/GitHubRepositorySearchStore.java
@@ -39,9 +39,6 @@ import io.reark.rxgithubapp.data.schematicProvider.GitHubProvider;
 import io.reark.rxgithubapp.data.schematicProvider.GitHubRepositorySearchColumns;
 import io.reark.rxgithubapp.pojo.GitHubRepositorySearch;
 
-/**
- * Created by ttuo on 07/01/15.
- */
 public class GitHubRepositorySearchStore extends SingleItemContentProviderStore<GitHubRepositorySearch, String> {
     private static final String TAG = GitHubRepositorySearchStore.class.getSimpleName();
 

--- a/app/src/main/java/io/reark/rxgithubapp/data/stores/GitHubRepositorySearchStore.java
+++ b/app/src/main/java/io/reark/rxgithubapp/data/stores/GitHubRepositorySearchStore.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.rxgithubapp.data.stores;
 
 import android.content.ContentResolver;

--- a/app/src/main/java/io/reark/rxgithubapp/data/stores/GitHubRepositoryStore.java
+++ b/app/src/main/java/io/reark/rxgithubapp/data/stores/GitHubRepositoryStore.java
@@ -61,7 +61,6 @@ public class GitHubRepositoryStore extends SingleItemContentProviderStore<GitHub
         return GitHubProvider.GitHubRepositories.GITHUB_REPOSITORIES;
     }
 
-
     @NonNull
     @Override
     protected String[] getProjection() {

--- a/app/src/main/java/io/reark/rxgithubapp/data/stores/GitHubRepositoryStore.java
+++ b/app/src/main/java/io/reark/rxgithubapp/data/stores/GitHubRepositoryStore.java
@@ -40,9 +40,6 @@ import io.reark.rxgithubapp.data.schematicProvider.JsonIdColumns;
 import io.reark.rxgithubapp.data.schematicProvider.UserSettingsColumns;
 import io.reark.rxgithubapp.pojo.GitHubRepository;
 
-/**
- * Created by ttuo on 07/01/15.
- */
 public class GitHubRepositoryStore extends SingleItemContentProviderStore<GitHubRepository, Integer> {
     private static final String TAG = GitHubRepositoryStore.class.getSimpleName();
 

--- a/app/src/main/java/io/reark/rxgithubapp/data/stores/GitHubRepositoryStore.java
+++ b/app/src/main/java/io/reark/rxgithubapp/data/stores/GitHubRepositoryStore.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.rxgithubapp.data.stores;
 
 import android.content.ContentResolver;

--- a/app/src/main/java/io/reark/rxgithubapp/data/stores/NetworkRequestStatusStore.java
+++ b/app/src/main/java/io/reark/rxgithubapp/data/stores/NetworkRequestStatusStore.java
@@ -41,9 +41,6 @@ import io.reark.rxgithubapp.data.schematicProvider.GitHubProvider;
 import io.reark.rxgithubapp.data.schematicProvider.JsonIdColumns;
 import io.reark.rxgithubapp.data.schematicProvider.UserSettingsColumns;
 
-/**
- * Created by ttuo on 26/04/15.
- */
 public class NetworkRequestStatusStore extends SingleItemContentProviderStore<NetworkRequestStatus, Integer> {
     private static final String TAG = NetworkRequestStatusStore.class.getSimpleName();
 

--- a/app/src/main/java/io/reark/rxgithubapp/data/stores/NetworkRequestStatusStore.java
+++ b/app/src/main/java/io/reark/rxgithubapp/data/stores/NetworkRequestStatusStore.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.rxgithubapp.data.stores;
 
 import android.content.ContentResolver;

--- a/app/src/main/java/io/reark/rxgithubapp/data/stores/StoreModule.java
+++ b/app/src/main/java/io/reark/rxgithubapp/data/stores/StoreModule.java
@@ -32,9 +32,6 @@ import javax.inject.Singleton;
 import dagger.Module;
 import dagger.Provides;
 
-/**
- * Created by Pawel Polanski on 5/16/15.
- */
 @Module
 public final class StoreModule {
 

--- a/app/src/main/java/io/reark/rxgithubapp/data/stores/StoreModule.java
+++ b/app/src/main/java/io/reark/rxgithubapp/data/stores/StoreModule.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.rxgithubapp.data.stores;
 
 import android.content.ContentResolver;

--- a/app/src/main/java/io/reark/rxgithubapp/data/stores/UserSettingsStore.java
+++ b/app/src/main/java/io/reark/rxgithubapp/data/stores/UserSettingsStore.java
@@ -41,9 +41,6 @@ import io.reark.rxgithubapp.data.schematicProvider.JsonIdColumns;
 import io.reark.rxgithubapp.data.schematicProvider.UserSettingsColumns;
 import io.reark.rxgithubapp.pojo.UserSettings;
 
-/**
- * Created by ttuo on 07/01/15.
- */
 public class UserSettingsStore extends SingleItemContentProviderStore<UserSettings, Integer> {
     private static final String TAG = UserSettingsStore.class.getSimpleName();
 

--- a/app/src/main/java/io/reark/rxgithubapp/data/stores/UserSettingsStore.java
+++ b/app/src/main/java/io/reark/rxgithubapp/data/stores/UserSettingsStore.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.rxgithubapp.data.stores;
 
 import android.content.ContentResolver;

--- a/app/src/main/java/io/reark/rxgithubapp/fragments/RepositoriesFragment.java
+++ b/app/src/main/java/io/reark/rxgithubapp/fragments/RepositoriesFragment.java
@@ -40,9 +40,6 @@ import io.reark.rxgithubapp.utils.ApplicationInstrumentation;
 import io.reark.rxgithubapp.view.RepositoriesView;
 import io.reark.rxgithubapp.viewmodels.RepositoriesViewModel;
 
-/**
- * Created by ttuo on 19/03/14.
- */
 public class RepositoriesFragment extends Fragment {
     private RepositoriesView.ViewBinder repositoriesViewBinder;
 

--- a/app/src/main/java/io/reark/rxgithubapp/fragments/RepositoriesFragment.java
+++ b/app/src/main/java/io/reark/rxgithubapp/fragments/RepositoriesFragment.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.rxgithubapp.fragments;
 
 import android.os.Bundle;

--- a/app/src/main/java/io/reark/rxgithubapp/fragments/RepositoryFragment.java
+++ b/app/src/main/java/io/reark/rxgithubapp/fragments/RepositoryFragment.java
@@ -40,9 +40,6 @@ import io.reark.rxgithubapp.utils.ApplicationInstrumentation;
 import io.reark.rxgithubapp.view.RepositoryView;
 import io.reark.rxgithubapp.viewmodels.RepositoryViewModel;
 
-/**
- * Created by ttuo on 06/04/15.
- */
 public class RepositoryFragment extends Fragment {
     private RepositoryView.ViewBinder repositoryViewBinder;
 

--- a/app/src/main/java/io/reark/rxgithubapp/fragments/RepositoryFragment.java
+++ b/app/src/main/java/io/reark/rxgithubapp/fragments/RepositoryFragment.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.rxgithubapp.fragments;
 
 import android.os.Bundle;

--- a/app/src/main/java/io/reark/rxgithubapp/injections/ApplicationModule.java
+++ b/app/src/main/java/io/reark/rxgithubapp/injections/ApplicationModule.java
@@ -34,9 +34,6 @@ import javax.inject.Singleton;
 import dagger.Module;
 import dagger.Provides;
 
-/**
- * Created by Pawel Polanski on 5/16/15.
- */
 @Module
 public class ApplicationModule {
 

--- a/app/src/main/java/io/reark/rxgithubapp/injections/ApplicationModule.java
+++ b/app/src/main/java/io/reark/rxgithubapp/injections/ApplicationModule.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.rxgithubapp.injections;
 
 import android.app.Application;

--- a/app/src/main/java/io/reark/rxgithubapp/injections/ForApplication.java
+++ b/app/src/main/java/io/reark/rxgithubapp/injections/ForApplication.java
@@ -31,9 +31,6 @@ import javax.inject.Qualifier;
 
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
-/**
- * Created by Pawel Polanski on 5/16/15.
- */
 @Qualifier
 @Retention(RUNTIME)
 public @interface ForApplication {

--- a/app/src/main/java/io/reark/rxgithubapp/injections/ForApplication.java
+++ b/app/src/main/java/io/reark/rxgithubapp/injections/ForApplication.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.rxgithubapp.injections;
 
 import java.lang.annotation.Retention;

--- a/app/src/main/java/io/reark/rxgithubapp/network/GitHubRepositorySearchResults.java
+++ b/app/src/main/java/io/reark/rxgithubapp/network/GitHubRepositorySearchResults.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.rxgithubapp.network;
 
 import android.support.annotation.NonNull;

--- a/app/src/main/java/io/reark/rxgithubapp/network/GitHubRepositorySearchResults.java
+++ b/app/src/main/java/io/reark/rxgithubapp/network/GitHubRepositorySearchResults.java
@@ -32,9 +32,6 @@ import java.util.List;
 import io.reark.reark.utils.Preconditions;
 import io.reark.rxgithubapp.pojo.GitHubRepository;
 
-/**
- * Created by ttuo on 11/01/15.
- */
 public class GitHubRepositorySearchResults {
 
     @NonNull

--- a/app/src/main/java/io/reark/rxgithubapp/network/GitHubService.java
+++ b/app/src/main/java/io/reark/rxgithubapp/network/GitHubService.java
@@ -35,9 +35,6 @@ import retrofit.http.Path;
 import retrofit.http.QueryMap;
 import rx.Observable;
 
-/**
- * Created by ttuo on 06/01/15.
- */
 public interface GitHubService {
     static Uri REPOSITORY_SEARCH = Uri.parse("github/search");
     static Uri REPOSITORY = Uri.parse("github/repository");

--- a/app/src/main/java/io/reark/rxgithubapp/network/GitHubService.java
+++ b/app/src/main/java/io/reark/rxgithubapp/network/GitHubService.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.rxgithubapp.network;
 
 import android.net.Uri;

--- a/app/src/main/java/io/reark/rxgithubapp/network/NetworkApi.java
+++ b/app/src/main/java/io/reark/rxgithubapp/network/NetworkApi.java
@@ -36,9 +36,6 @@ import retrofit.RestAdapter;
 import retrofit.client.Client;
 import rx.Observable;
 
-/**
- * Created by ttuo on 06/01/15.
- */
 public class NetworkApi {
 
     private final GitHubService gitHubService;

--- a/app/src/main/java/io/reark/rxgithubapp/network/NetworkApi.java
+++ b/app/src/main/java/io/reark/rxgithubapp/network/NetworkApi.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.rxgithubapp.network;
 
 import android.support.annotation.NonNull;

--- a/app/src/main/java/io/reark/rxgithubapp/network/NetworkInstrumentation.java
+++ b/app/src/main/java/io/reark/rxgithubapp/network/NetworkInstrumentation.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.rxgithubapp.network;
 
 import android.support.annotation.NonNull;

--- a/app/src/main/java/io/reark/rxgithubapp/network/NetworkInstrumentation.java
+++ b/app/src/main/java/io/reark/rxgithubapp/network/NetworkInstrumentation.java
@@ -29,10 +29,7 @@ import android.support.annotation.NonNull;
 
 import io.reark.rxgithubapp.utils.Instrumentation;
 
-public interface NetworkInstrumentation<T> extends Instrumentation
-{
-
+public interface NetworkInstrumentation<T> extends Instrumentation {
     @NonNull
     T decorateNetwork(@NonNull final T httpClient);
-
 }

--- a/app/src/main/java/io/reark/rxgithubapp/network/NetworkModule.java
+++ b/app/src/main/java/io/reark/rxgithubapp/network/NetworkModule.java
@@ -35,9 +35,6 @@ import dagger.Provides;
 import retrofit.client.Client;
 import retrofit.client.OkClient;
 
-/**
- * Created by Pawel Polanski on 5/16/15.
- */
 @Module
 public final class NetworkModule {
 

--- a/app/src/main/java/io/reark/rxgithubapp/network/NetworkModule.java
+++ b/app/src/main/java/io/reark/rxgithubapp/network/NetworkModule.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.rxgithubapp.network;
 
 import com.squareup.okhttp.OkHttpClient;

--- a/app/src/main/java/io/reark/rxgithubapp/network/NetworkService.java
+++ b/app/src/main/java/io/reark/rxgithubapp/network/NetworkService.java
@@ -34,9 +34,6 @@ import javax.inject.Inject;
 import io.reark.reark.utils.Log;
 import io.reark.rxgithubapp.RxGitHubApp;
 
-/**
- * Created by ttuo on 16/04/15.
- */
 public class NetworkService extends Service {
     private static final String TAG = NetworkService.class.getSimpleName();
 

--- a/app/src/main/java/io/reark/rxgithubapp/network/NetworkService.java
+++ b/app/src/main/java/io/reark/rxgithubapp/network/NetworkService.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.rxgithubapp.network;
 
 import android.app.Service;

--- a/app/src/main/java/io/reark/rxgithubapp/network/ServiceDataLayer.java
+++ b/app/src/main/java/io/reark/rxgithubapp/network/ServiceDataLayer.java
@@ -38,9 +38,6 @@ import io.reark.rxgithubapp.data.stores.GitHubRepositorySearchStore;
 import io.reark.rxgithubapp.data.stores.GitHubRepositoryStore;
 import io.reark.rxgithubapp.data.stores.NetworkRequestStatusStore;
 
-/**
- * Created by ttuo on 16/04/15.
- */
 public class ServiceDataLayer extends DataLayerBase {
     private static final String TAG = ServiceDataLayer.class.getSimpleName();
 

--- a/app/src/main/java/io/reark/rxgithubapp/network/ServiceDataLayer.java
+++ b/app/src/main/java/io/reark/rxgithubapp/network/ServiceDataLayer.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.rxgithubapp.network;
 
 import android.content.Intent;

--- a/app/src/main/java/io/reark/rxgithubapp/network/fetchers/AppFetcherBase.java
+++ b/app/src/main/java/io/reark/rxgithubapp/network/fetchers/AppFetcherBase.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.rxgithubapp.network.fetchers;
 
 import android.support.annotation.NonNull;

--- a/app/src/main/java/io/reark/rxgithubapp/network/fetchers/AppFetcherBase.java
+++ b/app/src/main/java/io/reark/rxgithubapp/network/fetchers/AppFetcherBase.java
@@ -33,9 +33,6 @@ import io.reark.reark.utils.Preconditions;
 import io.reark.rxgithubapp.network.NetworkApi;
 import rx.functions.Action1;
 
-/**
- * Created by antti on 25.10.2015.
- */
 public abstract class AppFetcherBase extends FetcherBase {
 
     @NonNull

--- a/app/src/main/java/io/reark/rxgithubapp/network/fetchers/FetcherModule.java
+++ b/app/src/main/java/io/reark/rxgithubapp/network/fetchers/FetcherModule.java
@@ -39,9 +39,6 @@ import io.reark.rxgithubapp.data.stores.NetworkRequestStatusStore;
 import io.reark.rxgithubapp.network.NetworkApi;
 import io.reark.rxgithubapp.network.NetworkModule;
 
-/**
- * Created by Pawel Polanski on 5/16/15.
- */
 @Module(includes = NetworkModule.class)
 public final class FetcherModule {
 

--- a/app/src/main/java/io/reark/rxgithubapp/network/fetchers/FetcherModule.java
+++ b/app/src/main/java/io/reark/rxgithubapp/network/fetchers/FetcherModule.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.rxgithubapp.network.fetchers;
 
 import java.util.Arrays;

--- a/app/src/main/java/io/reark/rxgithubapp/network/fetchers/GitHubRepositoryFetcher.java
+++ b/app/src/main/java/io/reark/rxgithubapp/network/fetchers/GitHubRepositoryFetcher.java
@@ -41,9 +41,6 @@ import rx.Subscription;
 import rx.functions.Action1;
 import rx.schedulers.Schedulers;
 
-/**
- * Created by ttuo on 16/04/15.
- */
 public class GitHubRepositoryFetcher extends AppFetcherBase {
     private static final String TAG = GitHubRepositoryFetcher.class.getSimpleName();
 

--- a/app/src/main/java/io/reark/rxgithubapp/network/fetchers/GitHubRepositoryFetcher.java
+++ b/app/src/main/java/io/reark/rxgithubapp/network/fetchers/GitHubRepositoryFetcher.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.rxgithubapp.network.fetchers;
 
 import android.content.Intent;

--- a/app/src/main/java/io/reark/rxgithubapp/network/fetchers/GitHubRepositorySearchFetcher.java
+++ b/app/src/main/java/io/reark/rxgithubapp/network/fetchers/GitHubRepositorySearchFetcher.java
@@ -47,9 +47,6 @@ import rx.Subscription;
 import rx.functions.Action1;
 import rx.schedulers.Schedulers;
 
-/**
- * Created by ttuo on 16/04/15.
- */
 public class GitHubRepositorySearchFetcher extends AppFetcherBase {
     private static final String TAG = GitHubRepositorySearchFetcher.class.getSimpleName();
 

--- a/app/src/main/java/io/reark/rxgithubapp/network/fetchers/GitHubRepositorySearchFetcher.java
+++ b/app/src/main/java/io/reark/rxgithubapp/network/fetchers/GitHubRepositorySearchFetcher.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.rxgithubapp.network.fetchers;
 
 import android.content.Intent;

--- a/app/src/main/java/io/reark/rxgithubapp/pojo/GitHubOwner.java
+++ b/app/src/main/java/io/reark/rxgithubapp/pojo/GitHubOwner.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.rxgithubapp.pojo;
 
 import android.support.annotation.NonNull;

--- a/app/src/main/java/io/reark/rxgithubapp/pojo/GitHubOwner.java
+++ b/app/src/main/java/io/reark/rxgithubapp/pojo/GitHubOwner.java
@@ -32,9 +32,6 @@ import com.google.gson.annotations.SerializedName;
 
 import io.reark.reark.utils.Preconditions;
 
-/**
- * Created by Pawel Polanski on 7/27/15.
- */
 public class GitHubOwner {
 
     @Nullable

--- a/app/src/main/java/io/reark/rxgithubapp/pojo/GitHubRepository.java
+++ b/app/src/main/java/io/reark/rxgithubapp/pojo/GitHubRepository.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.rxgithubapp.pojo;
 
 import android.support.annotation.NonNull;

--- a/app/src/main/java/io/reark/rxgithubapp/pojo/GitHubRepository.java
+++ b/app/src/main/java/io/reark/rxgithubapp/pojo/GitHubRepository.java
@@ -32,9 +32,6 @@ import com.google.gson.annotations.SerializedName;
 
 import io.reark.reark.utils.Preconditions;
 
-/**
- * Created by ttuo on 06/01/15.
- */
 public class GitHubRepository {
     final private int id;
 

--- a/app/src/main/java/io/reark/rxgithubapp/pojo/GitHubRepositorySearch.java
+++ b/app/src/main/java/io/reark/rxgithubapp/pojo/GitHubRepositorySearch.java
@@ -27,9 +27,6 @@ package io.reark.rxgithubapp.pojo;
 
 import java.util.List;
 
-/**
- * Created by ttuo on 06/01/15.
- */
 public class GitHubRepositorySearch {
     final private String search;
     final private List<Integer> items;

--- a/app/src/main/java/io/reark/rxgithubapp/pojo/GitHubRepositorySearch.java
+++ b/app/src/main/java/io/reark/rxgithubapp/pojo/GitHubRepositorySearch.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.rxgithubapp.pojo;
 
 import java.util.List;

--- a/app/src/main/java/io/reark/rxgithubapp/pojo/UserSettings.java
+++ b/app/src/main/java/io/reark/rxgithubapp/pojo/UserSettings.java
@@ -25,9 +25,6 @@
  */
 package io.reark.rxgithubapp.pojo;
 
-/**
- * Created by ttuo on 06/04/15.
- */
 public class UserSettings {
     private final int selectedRepositoryId;
 

--- a/app/src/main/java/io/reark/rxgithubapp/pojo/UserSettings.java
+++ b/app/src/main/java/io/reark/rxgithubapp/pojo/UserSettings.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.rxgithubapp.pojo;
 
 /**

--- a/app/src/main/java/io/reark/rxgithubapp/utils/ApplicationInstrumentation.java
+++ b/app/src/main/java/io/reark/rxgithubapp/utils/ApplicationInstrumentation.java
@@ -26,10 +26,8 @@
 package io.reark.rxgithubapp.utils;
 
 import android.support.annotation.NonNull;
-public interface ApplicationInstrumentation extends Instrumentation
-{
 
+public interface ApplicationInstrumentation extends Instrumentation {
     @NonNull
     LeakTracing getLeakTracing();
-
 }

--- a/app/src/main/java/io/reark/rxgithubapp/utils/ApplicationInstrumentation.java
+++ b/app/src/main/java/io/reark/rxgithubapp/utils/ApplicationInstrumentation.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.rxgithubapp.utils;
 
 import android.support.annotation.NonNull;

--- a/app/src/main/java/io/reark/rxgithubapp/utils/Instrumentation.java
+++ b/app/src/main/java/io/reark/rxgithubapp/utils/Instrumentation.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.rxgithubapp.utils;
 
 public interface Instrumentation

--- a/app/src/main/java/io/reark/rxgithubapp/utils/Instrumentation.java
+++ b/app/src/main/java/io/reark/rxgithubapp/utils/Instrumentation.java
@@ -25,9 +25,6 @@
  */
 package io.reark.rxgithubapp.utils;
 
-public interface Instrumentation
-{
-
+public interface Instrumentation {
     void init();
-
 }

--- a/app/src/main/java/io/reark/rxgithubapp/utils/LeakTracing.java
+++ b/app/src/main/java/io/reark/rxgithubapp/utils/LeakTracing.java
@@ -25,9 +25,6 @@
  */
 package io.reark.rxgithubapp.utils;
 
-/**
- * Created by Pawel Polanski on 5/9/15.
- */
 public interface LeakTracing extends Instrumentation {
 
     void traceLeakage(Object reference);

--- a/app/src/main/java/io/reark/rxgithubapp/utils/LeakTracing.java
+++ b/app/src/main/java/io/reark/rxgithubapp/utils/LeakTracing.java
@@ -26,7 +26,5 @@
 package io.reark.rxgithubapp.utils;
 
 public interface LeakTracing extends Instrumentation {
-
     void traceLeakage(Object reference);
-
 }

--- a/app/src/main/java/io/reark/rxgithubapp/utils/LeakTracing.java
+++ b/app/src/main/java/io/reark/rxgithubapp/utils/LeakTracing.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.rxgithubapp.utils;
 
 /**

--- a/app/src/main/java/io/reark/rxgithubapp/utils/NullNetworkInstrumentation.java
+++ b/app/src/main/java/io/reark/rxgithubapp/utils/NullNetworkInstrumentation.java
@@ -30,11 +30,8 @@ import android.support.annotation.NonNull;
 import com.squareup.okhttp.OkHttpClient;
 
 import io.reark.rxgithubapp.network.NetworkInstrumentation;
-/**
- * Created by Pawel Polanski on 7/18/15.
- */
-public class NullNetworkInstrumentation implements NetworkInstrumentation<OkHttpClient> {
 
+public class NullNetworkInstrumentation implements NetworkInstrumentation<OkHttpClient> {
     @NonNull
     @Override
     public OkHttpClient decorateNetwork(@NonNull OkHttpClient httpClient) {

--- a/app/src/main/java/io/reark/rxgithubapp/utils/NullNetworkInstrumentation.java
+++ b/app/src/main/java/io/reark/rxgithubapp/utils/NullNetworkInstrumentation.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.rxgithubapp.utils;
 
 import android.support.annotation.NonNull;

--- a/app/src/main/java/io/reark/rxgithubapp/utils/SubscriptionUtils.java
+++ b/app/src/main/java/io/reark/rxgithubapp/utils/SubscriptionUtils.java
@@ -42,6 +42,7 @@ public class SubscriptionUtils {
                                                      @NonNull final TextView textView) {
         return subscribeTextViewText(observable, textView, AndroidSchedulers.mainThread());
     }
+
     static public Subscription subscribeTextViewText(@NonNull final Observable<String> observable,
                                                      @NonNull final TextView textView,
                                                      @NonNull Scheduler scheduler) {
@@ -58,5 +59,4 @@ public class SubscriptionUtils {
                         }
                 );
     }
-
 }

--- a/app/src/main/java/io/reark/rxgithubapp/utils/SubscriptionUtils.java
+++ b/app/src/main/java/io/reark/rxgithubapp/utils/SubscriptionUtils.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.rxgithubapp.utils;
 
 import android.graphics.Color;

--- a/app/src/main/java/io/reark/rxgithubapp/utils/SubscriptionUtils.java
+++ b/app/src/main/java/io/reark/rxgithubapp/utils/SubscriptionUtils.java
@@ -35,9 +35,6 @@ import rx.Scheduler;
 import rx.Subscription;
 import rx.android.schedulers.AndroidSchedulers;
 
-/**
- * Created by ttuo on 13/06/14.
- */
 public class SubscriptionUtils {
     private SubscriptionUtils() { }
 

--- a/app/src/main/java/io/reark/rxgithubapp/utils/glide/NullTarget.java
+++ b/app/src/main/java/io/reark/rxgithubapp/utils/glide/NullTarget.java
@@ -33,9 +33,6 @@ import com.bumptech.glide.request.animation.GlideAnimation;
 import com.bumptech.glide.request.target.SizeReadyCallback;
 import com.bumptech.glide.request.target.Target;
 
-/**
- * Created by Pawel Polanski on 8/7/15.
- */
 public class NullTarget<T> implements Target<T> {
 
     private static final Target<Object> EMPTY = new NullTarget<>();

--- a/app/src/main/java/io/reark/rxgithubapp/utils/glide/NullTarget.java
+++ b/app/src/main/java/io/reark/rxgithubapp/utils/glide/NullTarget.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.rxgithubapp.utils.glide;
 
 import android.graphics.drawable.Drawable;

--- a/app/src/main/java/io/reark/rxgithubapp/utils/glide/SerialTarget.java
+++ b/app/src/main/java/io/reark/rxgithubapp/utils/glide/SerialTarget.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.rxgithubapp.utils.glide;
 
 import android.graphics.drawable.Drawable;

--- a/app/src/main/java/io/reark/rxgithubapp/utils/glide/SerialTarget.java
+++ b/app/src/main/java/io/reark/rxgithubapp/utils/glide/SerialTarget.java
@@ -44,7 +44,6 @@ public class SerialTarget<T> implements Target<T> {
     private static final AtomicReferenceFieldUpdater<SerialTarget, State> STATE_UPDATER
             = AtomicReferenceFieldUpdater.newUpdater(SerialTarget.class, State.class, "state");
 
-
     private static final class State<T> {
 
         final Target<T> target;

--- a/app/src/main/java/io/reark/rxgithubapp/utils/glide/SerialTarget.java
+++ b/app/src/main/java/io/reark/rxgithubapp/utils/glide/SerialTarget.java
@@ -37,9 +37,6 @@ import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 
 import io.reark.reark.utils.Preconditions;
 
-/**
- * Created by Pawel Polanski on 8/7/15.
- */
 public class SerialTarget<T> implements Target<T> {
 
     private volatile State<T> state = new State<>(NullTarget.empty());

--- a/app/src/main/java/io/reark/rxgithubapp/view/RepositoriesAdapter.java
+++ b/app/src/main/java/io/reark/rxgithubapp/view/RepositoriesAdapter.java
@@ -40,9 +40,6 @@ import java.util.List;
 import io.reark.rxgithubapp.R;
 import io.reark.rxgithubapp.pojo.GitHubRepository;
 
-/**
- * Created by Pawel Polanski on 7/27/15.
- */
 public class RepositoriesAdapter extends RecyclerView.Adapter<RepositoriesAdapter.ViewHolder> {
 
     private final List<GitHubRepository> gitHubRepositories = new ArrayList<>();

--- a/app/src/main/java/io/reark/rxgithubapp/view/RepositoriesAdapter.java
+++ b/app/src/main/java/io/reark/rxgithubapp/view/RepositoriesAdapter.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.rxgithubapp.view;
 
 import android.support.v7.widget.RecyclerView;

--- a/app/src/main/java/io/reark/rxgithubapp/view/RepositoriesView.java
+++ b/app/src/main/java/io/reark/rxgithubapp/view/RepositoriesView.java
@@ -118,7 +118,6 @@ public class RepositoriesView extends FrameLayout {
         statusText.setText(networkRequestStatusText);
     }
 
-
     public static class ViewBinder extends RxViewBinder {
         private RepositoriesView view;
         private RepositoriesViewModel viewModel;

--- a/app/src/main/java/io/reark/rxgithubapp/view/RepositoriesView.java
+++ b/app/src/main/java/io/reark/rxgithubapp/view/RepositoriesView.java
@@ -50,9 +50,6 @@ import rx.android.schedulers.AndroidSchedulers;
 import rx.subscriptions.CompositeSubscription;
 import rx.subscriptions.Subscriptions;
 
-/**
- * Created by ttuo on 06/01/15.
- */
 public class RepositoriesView extends FrameLayout {
 
     private TextView statusText;

--- a/app/src/main/java/io/reark/rxgithubapp/view/RepositoriesView.java
+++ b/app/src/main/java/io/reark/rxgithubapp/view/RepositoriesView.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.rxgithubapp.view;
 
 import android.content.Context;

--- a/app/src/main/java/io/reark/rxgithubapp/view/RepositoryView.java
+++ b/app/src/main/java/io/reark/rxgithubapp/view/RepositoryView.java
@@ -44,9 +44,6 @@ import io.reark.rxgithubapp.viewmodels.RepositoryViewModel;
 import rx.android.schedulers.AndroidSchedulers;
 import rx.subscriptions.CompositeSubscription;
 
-/**
- * Created by ttuo on 06/04/15.
- */
 public class RepositoryView extends FrameLayout {
     private TextView titleTextView;
     private TextView stargazersTextView;

--- a/app/src/main/java/io/reark/rxgithubapp/view/RepositoryView.java
+++ b/app/src/main/java/io/reark/rxgithubapp/view/RepositoryView.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.rxgithubapp.view;
 
 import android.content.Context;

--- a/app/src/main/java/io/reark/rxgithubapp/viewmodels/RepositoriesViewModel.java
+++ b/app/src/main/java/io/reark/rxgithubapp/viewmodels/RepositoriesViewModel.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.rxgithubapp.viewmodels;
 
 import android.support.annotation.NonNull;

--- a/app/src/main/java/io/reark/rxgithubapp/viewmodels/RepositoriesViewModel.java
+++ b/app/src/main/java/io/reark/rxgithubapp/viewmodels/RepositoriesViewModel.java
@@ -45,9 +45,6 @@ import rx.subjects.BehaviorSubject;
 import rx.subjects.PublishSubject;
 import rx.subscriptions.CompositeSubscription;
 
-/**
- * Created by ttuo on 19/03/14.
- */
 public class RepositoriesViewModel extends AbstractViewModel {
     private static final String TAG = RepositoriesViewModel.class.getSimpleName();
 

--- a/app/src/main/java/io/reark/rxgithubapp/viewmodels/RepositoryViewModel.java
+++ b/app/src/main/java/io/reark/rxgithubapp/viewmodels/RepositoryViewModel.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.rxgithubapp.viewmodels;
 
 import android.support.annotation.NonNull;

--- a/app/src/main/java/io/reark/rxgithubapp/viewmodels/RepositoryViewModel.java
+++ b/app/src/main/java/io/reark/rxgithubapp/viewmodels/RepositoryViewModel.java
@@ -37,9 +37,6 @@ import rx.Observable;
 import rx.subjects.BehaviorSubject;
 import rx.subscriptions.CompositeSubscription;
 
-/**
- * Created by ttuo on 06/04/15.
- */
 public class RepositoryViewModel extends AbstractViewModel {
     private static final String TAG = RepositoryViewModel.class.getSimpleName();
 

--- a/app/src/main/java/io/reark/rxgithubapp/viewmodels/ViewModelModule.java
+++ b/app/src/main/java/io/reark/rxgithubapp/viewmodels/ViewModelModule.java
@@ -32,9 +32,6 @@ import io.reark.rxgithubapp.data.DataLayer.GetGitHubRepository;
 import io.reark.rxgithubapp.data.DataLayer.GetGitHubRepositorySearch;
 import io.reark.rxgithubapp.data.DataLayer.GetUserSettings;
 
-/**
- * Created by Pawel Polanski on 5/16/15.
- */
 @Module
 public class ViewModelModule {
 

--- a/app/src/main/java/io/reark/rxgithubapp/viewmodels/ViewModelModule.java
+++ b/app/src/main/java/io/reark/rxgithubapp/viewmodels/ViewModelModule.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.rxgithubapp.viewmodels;
 
 import dagger.Module;

--- a/app/src/main/java/io/reark/rxgithubapp/widget/WidgetProvider.java
+++ b/app/src/main/java/io/reark/rxgithubapp/widget/WidgetProvider.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.rxgithubapp.widget;
 
 import android.appwidget.AppWidgetManager;

--- a/app/src/main/java/io/reark/rxgithubapp/widget/WidgetProvider.java
+++ b/app/src/main/java/io/reark/rxgithubapp/widget/WidgetProvider.java
@@ -30,9 +30,6 @@ import android.appwidget.AppWidgetProvider;
 import android.content.Context;
 import android.content.Intent;
 
-/**
- * Created by ttuo on 26/03/15.
- */
 public class WidgetProvider extends AppWidgetProvider {
 
     public void onUpdate(Context context, AppWidgetManager appWidgetManager, int[] appWidgetIds) {

--- a/app/src/main/java/io/reark/rxgithubapp/widget/WidgetRemoteViewFactory.java
+++ b/app/src/main/java/io/reark/rxgithubapp/widget/WidgetRemoteViewFactory.java
@@ -32,9 +32,6 @@ import android.widget.RemoteViewsService;
 import io.reark.reark.utils.Log;
 import io.reark.rxgithubapp.R;
 
-/**
- * Created by ttuo on 26/03/15.
- */
 public class WidgetRemoteViewFactory implements RemoteViewsService.RemoteViewsFactory {
     private static final String TAG = WidgetRemoteViewFactory.class.getSimpleName();
     final private Context context;

--- a/app/src/main/java/io/reark/rxgithubapp/widget/WidgetRemoteViewFactory.java
+++ b/app/src/main/java/io/reark/rxgithubapp/widget/WidgetRemoteViewFactory.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.rxgithubapp.widget;
 
 import android.content.Context;

--- a/app/src/main/java/io/reark/rxgithubapp/widget/WidgetService.java
+++ b/app/src/main/java/io/reark/rxgithubapp/widget/WidgetService.java
@@ -44,9 +44,6 @@ import io.reark.rxgithubapp.pojo.UserSettings;
 import rx.android.schedulers.AndroidSchedulers;
 import rx.subscriptions.CompositeSubscription;
 
-/**
- * Created by ttuo on 26/03/15.
- */
 public class WidgetService extends Service {
     private static final String TAG = WidgetService.class.getSimpleName();
 

--- a/app/src/main/java/io/reark/rxgithubapp/widget/WidgetService.java
+++ b/app/src/main/java/io/reark/rxgithubapp/widget/WidgetService.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.rxgithubapp.widget;
 
 import android.app.Service;

--- a/app/src/release/java/io/reark/rxbookapp/injections/Graph.java
+++ b/app/src/release/java/io/reark/rxbookapp/injections/Graph.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.rxgithubapp.injections;
 
 import android.app.Application;

--- a/app/src/release/java/io/reark/rxbookapp/injections/Graph.java
+++ b/app/src/release/java/io/reark/rxbookapp/injections/Graph.java
@@ -41,9 +41,6 @@ import io.reark.rxgithubapp.viewmodels.RepositoryViewModel;
 import io.reark.rxgithubapp.viewmodels.ViewModelModule;
 import io.reark.rxgithubapp.widget.WidgetService;
 
-/**
- * Created by pt2121 on 2/20/15.
- */
 @Singleton
 @Component(modules = {ApplicationModule.class, DataStoreModule.class, ViewModelModule.class,
                       InstrumentationModule.class})

--- a/app/src/release/java/io/reark/rxbookapp/injections/InstrumentationModule.java
+++ b/app/src/release/java/io/reark/rxbookapp/injections/InstrumentationModule.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.rxgithubapp.injections;
 
 import android.content.Context;

--- a/app/src/release/java/io/reark/rxbookapp/injections/InstrumentationModule.java
+++ b/app/src/release/java/io/reark/rxbookapp/injections/InstrumentationModule.java
@@ -38,9 +38,6 @@ import io.reark.rxgithubapp.utils.ApplicationInstrumentation;
 import io.reark.rxgithubapp.utils.NullInstrumentation;
 import io.reark.rxgithubapp.utils.NullNetworkInstrumentation;
 
-/**
- * Created by Pawel Polanski on 4/24/15.
- */
 @Module
 public class InstrumentationModule {
 

--- a/app/src/release/java/io/reark/rxbookapp/utils/NullInstrumentation.java
+++ b/app/src/release/java/io/reark/rxbookapp/utils/NullInstrumentation.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.rxgithubapp.utils;
 
 import android.content.Context;

--- a/app/src/release/java/io/reark/rxbookapp/utils/NullInstrumentation.java
+++ b/app/src/release/java/io/reark/rxbookapp/utils/NullInstrumentation.java
@@ -28,9 +28,7 @@ package io.reark.rxgithubapp.utils;
 import android.content.Context;
 import android.support.annotation.NonNull;
 
-public class NullInstrumentation implements ApplicationInstrumentation
-{
-
+public class NullInstrumentation implements ApplicationInstrumentation {
     @SuppressWarnings("unused")
     public NullInstrumentation(Context context) { }
 
@@ -42,5 +40,4 @@ public class NullInstrumentation implements ApplicationInstrumentation
     public LeakTracing getLeakTracing() {
         return new NullLeakTracing();
     }
-
 }

--- a/app/src/release/java/io/reark/rxbookapp/utils/NullLeakTracing.java
+++ b/app/src/release/java/io/reark/rxbookapp/utils/NullLeakTracing.java
@@ -25,9 +25,6 @@
  */
 package io.reark.rxgithubapp.utils;
 
-/**
- * Created by Pawel Polanski on 5/9/15.
- */
 public class NullLeakTracing implements LeakTracing {
 
     @Override

--- a/app/src/release/java/io/reark/rxbookapp/utils/NullLeakTracing.java
+++ b/app/src/release/java/io/reark/rxbookapp/utils/NullLeakTracing.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.rxgithubapp.utils;
 
 /**

--- a/app/src/test/java/io/reark/rxbookapp/utils/NullNetworkInstrumentationTest.java
+++ b/app/src/test/java/io/reark/rxbookapp/utils/NullNetworkInstrumentationTest.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.rxgithubapp.utils;
 
 import com.squareup.okhttp.OkHttpClient;

--- a/app/src/test/java/io/reark/rxbookapp/utils/NullNetworkInstrumentationTest.java
+++ b/app/src/test/java/io/reark/rxbookapp/utils/NullNetworkInstrumentationTest.java
@@ -33,9 +33,6 @@ import org.junit.Test;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyZeroInteractions;
 
-/**
- * Created by Pawel Polanski on 7/20/15.
- */
 public class NullNetworkInstrumentationTest {
 
     private NullNetworkInstrumentation instrumentation;

--- a/app/src/test/java/io/reark/rxbookapp/utils/SubscriptionUtilsTest.java
+++ b/app/src/test/java/io/reark/rxbookapp/utils/SubscriptionUtilsTest.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.rxgithubapp.utils;
 
 import android.graphics.Color;

--- a/app/src/test/java/io/reark/rxbookapp/viewmodels/RepositoriesViewModelTest.java
+++ b/app/src/test/java/io/reark/rxbookapp/viewmodels/RepositoriesViewModelTest.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.rxgithubapp.viewmodels;
 
 import org.junit.Before;

--- a/app/src/test/java/io/reark/rxbookapp/viewmodels/RepositoriesViewModelTest.java
+++ b/app/src/test/java/io/reark/rxbookapp/viewmodels/RepositoriesViewModelTest.java
@@ -48,9 +48,6 @@ import static io.reark.rxgithubapp.viewmodels.RepositoriesViewModel.toProgressSt
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 
-/**
- * Created by Pawel Polanski on 5/31/15.
- */
 public class RepositoriesViewModelTest {
 
     private RepositoriesViewModel viewModel;

--- a/app/src/test/java/io/reark/rxbookapp/viewmodels/RepositoryViewModelTest.java
+++ b/app/src/test/java/io/reark/rxbookapp/viewmodels/RepositoryViewModelTest.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.rxgithubapp.viewmodels;
 
 import org.junit.Test;

--- a/app/src/testDebug/java/io/reark/rxbookapp/utils/DebugApplicationInstrumentationTest.java
+++ b/app/src/testDebug/java/io/reark/rxbookapp/utils/DebugApplicationInstrumentationTest.java
@@ -32,9 +32,6 @@ import org.mockito.MockitoAnnotations;
 
 import static org.mockito.Mockito.verify;
 
-/**
- * Created by Pawel Polanski on 7/20/15.
- */
 public class DebugApplicationInstrumentationTest {
 
     private DebugApplicationInstrumentation applicationInstrumentation;

--- a/app/src/testDebug/java/io/reark/rxbookapp/utils/DebugApplicationInstrumentationTest.java
+++ b/app/src/testDebug/java/io/reark/rxbookapp/utils/DebugApplicationInstrumentationTest.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.rxgithubapp.utils;
 
 import org.junit.Before;

--- a/app/src/testDebug/java/io/reark/rxbookapp/utils/StethoInstrumentationTest.java
+++ b/app/src/testDebug/java/io/reark/rxbookapp/utils/StethoInstrumentationTest.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.rxgithubapp.utils;
 
 import android.content.Context;

--- a/app/src/testDebug/java/io/reark/rxbookapp/utils/StethoInstrumentationTest.java
+++ b/app/src/testDebug/java/io/reark/rxbookapp/utils/StethoInstrumentationTest.java
@@ -44,9 +44,6 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-/**
- * Created by Pawel Polanski on 7/20/15.
- */
 public class StethoInstrumentationTest {
 
     private StethoInstrumentation instrumentation;

--- a/reark/src/main/java/io/reark/reark/data/DataStreamNotification.java
+++ b/reark/src/main/java/io/reark/reark/data/DataStreamNotification.java
@@ -30,9 +30,6 @@ import android.support.annotation.Nullable;
 
 import io.reark.reark.utils.Preconditions;
 
-/**
- * Created by ttuo on 06/05/15.
- */
 public class DataStreamNotification<T> {
 
     private enum Type {

--- a/reark/src/main/java/io/reark/reark/data/DataStreamNotification.java
+++ b/reark/src/main/java/io/reark/reark/data/DataStreamNotification.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.reark.data;
 
 import android.support.annotation.NonNull;

--- a/reark/src/main/java/io/reark/reark/data/store/ContentProviderStore.java
+++ b/reark/src/main/java/io/reark/reark/data/store/ContentProviderStore.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.reark.data.store;
 
 import android.content.ContentResolver;

--- a/reark/src/main/java/io/reark/reark/data/store/SingleItemContentProviderStore.java
+++ b/reark/src/main/java/io/reark/reark/data/store/SingleItemContentProviderStore.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.reark.data.store;
 
 import android.content.ContentResolver;

--- a/reark/src/main/java/io/reark/reark/data/store/StoreItem.java
+++ b/reark/src/main/java/io/reark/reark/data/store/StoreItem.java
@@ -78,7 +78,6 @@ class StoreItem<T> {
         return result;
     }
 
-
     @Override
     public String toString() {
         final StringBuffer sb = new StringBuffer("StoreItem{");

--- a/reark/src/main/java/io/reark/reark/data/store/StoreItem.java
+++ b/reark/src/main/java/io/reark/reark/data/store/StoreItem.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.reark.data.store;
 
 import android.net.Uri;

--- a/reark/src/main/java/io/reark/reark/data/store/StoreItem.java
+++ b/reark/src/main/java/io/reark/reark/data/store/StoreItem.java
@@ -31,9 +31,6 @@ import android.support.annotation.Nullable;
 
 import io.reark.reark.utils.Preconditions;
 
-/**
- * Created by Pawel Polanski on 12/28/15.
- */
 class StoreItem<T> {
 
     @NonNull

--- a/reark/src/main/java/io/reark/reark/data/utils/DataLayerUtils.java
+++ b/reark/src/main/java/io/reark/reark/data/utils/DataLayerUtils.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.reark.data.utils;
 
 import android.support.annotation.NonNull;

--- a/reark/src/main/java/io/reark/reark/data/utils/DataLayerUtils.java
+++ b/reark/src/main/java/io/reark/reark/data/utils/DataLayerUtils.java
@@ -32,9 +32,6 @@ import io.reark.reark.pojo.NetworkRequestStatus;
 import rx.Observable;
 import rx.functions.Func1;
 
-/**
- * Created by ttuo on 06/05/15.
- */
 public class DataLayerUtils {
     private DataLayerUtils() {
 

--- a/reark/src/main/java/io/reark/reark/network/fetchers/Fetcher.java
+++ b/reark/src/main/java/io/reark/reark/network/fetchers/Fetcher.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.reark.network.fetchers;
 
 import android.content.Intent;

--- a/reark/src/main/java/io/reark/reark/network/fetchers/Fetcher.java
+++ b/reark/src/main/java/io/reark/reark/network/fetchers/Fetcher.java
@@ -28,9 +28,6 @@ package io.reark.reark.network.fetchers;
 import android.content.Intent;
 import android.net.Uri;
 
-/**
- * Created by ttuo on 16/04/15.
- */
 public interface Fetcher<T> {
     void fetch(Intent intent);
     T getServiceUri();

--- a/reark/src/main/java/io/reark/reark/network/fetchers/FetcherBase.java
+++ b/reark/src/main/java/io/reark/reark/network/fetchers/FetcherBase.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.reark.network.fetchers;
 
 import android.support.annotation.NonNull;

--- a/reark/src/main/java/io/reark/reark/network/fetchers/FetcherBase.java
+++ b/reark/src/main/java/io/reark/reark/network/fetchers/FetcherBase.java
@@ -37,9 +37,6 @@ import retrofit.RetrofitError;
 import rx.Subscription;
 import rx.functions.Action1;
 
-/**
- * Created by ttuo on 16/04/15.
- */
 abstract public class FetcherBase implements Fetcher {
     private static final String TAG = FetcherBase.class.getSimpleName();
 

--- a/reark/src/main/java/io/reark/reark/network/fetchers/FetcherManagerBase.java
+++ b/reark/src/main/java/io/reark/reark/network/fetchers/FetcherManagerBase.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.reark.network.fetchers;
 
 import android.net.Uri;

--- a/reark/src/main/java/io/reark/reark/network/fetchers/FetcherManagerBase.java
+++ b/reark/src/main/java/io/reark/reark/network/fetchers/FetcherManagerBase.java
@@ -34,9 +34,6 @@ import java.util.Collection;
 
 import io.reark.reark.utils.Preconditions;
 
-/**
- * Created by ttuo on 13/12/15.
- */
 public abstract class FetcherManagerBase<T> {
     @NonNull
     final private Collection<Fetcher<T>> fetchers;

--- a/reark/src/main/java/io/reark/reark/network/fetchers/UriFetcherManager.java
+++ b/reark/src/main/java/io/reark/reark/network/fetchers/UriFetcherManager.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.reark.network.fetchers;
 
 import android.net.Uri;

--- a/reark/src/main/java/io/reark/reark/network/fetchers/UriFetcherManager.java
+++ b/reark/src/main/java/io/reark/reark/network/fetchers/UriFetcherManager.java
@@ -31,9 +31,6 @@ import android.support.annotation.NonNull;
 import java.util.ArrayList;
 import java.util.Collection;
 
-/**
- * Created by ttuo on 13/12/15.
- */
 public class UriFetcherManager extends FetcherManagerBase<Uri> {
     private UriFetcherManager(Collection<Fetcher<Uri>> fetchers) {
         super(fetchers);

--- a/reark/src/main/java/io/reark/reark/pojo/NetworkRequestStatus.java
+++ b/reark/src/main/java/io/reark/reark/pojo/NetworkRequestStatus.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.reark.pojo;
 
 /**

--- a/reark/src/main/java/io/reark/reark/pojo/NetworkRequestStatus.java
+++ b/reark/src/main/java/io/reark/reark/pojo/NetworkRequestStatus.java
@@ -25,9 +25,6 @@
  */
 package io.reark.reark.pojo;
 
-/**
- * Created by ttuo on 26/04/15.
- */
 public class NetworkRequestStatus {
     private static final String NETWORK_STATUS_ONGOING = "networkStatusOngoing";
     private static final String NETWORK_STATUS_ERROR = "networkStatusError";

--- a/reark/src/main/java/io/reark/reark/utils/Log.java
+++ b/reark/src/main/java/io/reark/reark/utils/Log.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.reark.utils;
 
 /**

--- a/reark/src/main/java/io/reark/reark/utils/RxUtils.java
+++ b/reark/src/main/java/io/reark/reark/utils/RxUtils.java
@@ -32,9 +32,6 @@ import java.util.List;
 
 import rx.Observable;
 
-/**
- * Created by Pawel Polanski on 6/4/15.
- */
 public final class RxUtils {
 
     private RxUtils() {

--- a/reark/src/main/java/io/reark/reark/utils/RxUtils.java
+++ b/reark/src/main/java/io/reark/reark/utils/RxUtils.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.reark.utils;
 
 import android.support.annotation.NonNull;

--- a/reark/src/main/java/io/reark/reark/utils/RxViewBinder.java
+++ b/reark/src/main/java/io/reark/reark/utils/RxViewBinder.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.reark.utils;
 
 import android.support.annotation.NonNull;

--- a/reark/src/main/java/io/reark/reark/utils/RxViewBinder.java
+++ b/reark/src/main/java/io/reark/reark/utils/RxViewBinder.java
@@ -30,9 +30,6 @@ import android.support.annotation.Nullable;
 
 import rx.subscriptions.CompositeSubscription;
 
-/**
- * Created by ttuo on 19/08/15.
- */
 public abstract class RxViewBinder {
 
     @Nullable

--- a/reark/src/main/java/io/reark/reark/utils/TextWatcherObservable.java
+++ b/reark/src/main/java/io/reark/reark/utils/TextWatcherObservable.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.reark.utils;
 
 import android.support.annotation.NonNull;

--- a/reark/src/main/java/io/reark/reark/utils/TextWatcherObservable.java
+++ b/reark/src/main/java/io/reark/reark/utils/TextWatcherObservable.java
@@ -35,9 +35,6 @@ import rx.Subscriber;
 import rx.subjects.BehaviorSubject;
 import rx.subjects.Subject;
 
-/**
- * Created by ttuo on 27/01/15.
- */
 public class TextWatcherObservable {
     static public Observable<String> create(@NonNull EditText editText) {
         Preconditions.checkNotNull(editText, "Edit Text cannot be null.");

--- a/reark/src/main/java/io/reark/reark/viewmodels/AbstractViewModel.java
+++ b/reark/src/main/java/io/reark/reark/viewmodels/AbstractViewModel.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.reark.viewmodels;
 
 import android.support.annotation.NonNull;

--- a/reark/src/main/java/io/reark/reark/viewmodels/AbstractViewModel.java
+++ b/reark/src/main/java/io/reark/reark/viewmodels/AbstractViewModel.java
@@ -30,9 +30,6 @@ import android.support.annotation.NonNull;
 import io.reark.reark.utils.Log;
 import rx.subscriptions.CompositeSubscription;
 
-/**
- * Created by ttuo on 06/04/15.
- */
 abstract public class AbstractViewModel {
     private static final String TAG = AbstractViewModel.class.getSimpleName();
     private CompositeSubscription compositeSubscription;

--- a/reark/src/test/java/io/reark/reark/network/fetchers/FetcherManagerBaseTest.java
+++ b/reark/src/test/java/io/reark/reark/network/fetchers/FetcherManagerBaseTest.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.reark.network.fetchers;
 
 import org.junit.Test;

--- a/reark/src/test/java/io/reark/reark/network/fetchers/FetcherManagerBaseTest.java
+++ b/reark/src/test/java/io/reark/reark/network/fetchers/FetcherManagerBaseTest.java
@@ -35,9 +35,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.*;
 
-/**
- * Created by ttuo on 13/12/15.
- */
 public class FetcherManagerBaseTest {
 
     @Test

--- a/reark/src/test/java/io/reark/reark/utils/RxUtilsTest.java
+++ b/reark/src/test/java/io/reark/reark/utils/RxUtilsTest.java
@@ -35,9 +35,6 @@ import rx.observers.TestSubscriber;
 
 import static org.junit.Assert.assertEquals;
 
-/**
- * Created by Pawel Polanski on 6/4/15.
- */
 public class RxUtilsTest {
 
     @Test

--- a/reark/src/test/java/io/reark/reark/utils/RxUtilsTest.java
+++ b/reark/src/test/java/io/reark/reark/utils/RxUtilsTest.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.reark.utils;
 
 import org.junit.Test;

--- a/reark/src/test/java/io/reark/reark/utils/RxViewBinderTest.java
+++ b/reark/src/test/java/io/reark/reark/utils/RxViewBinderTest.java
@@ -136,7 +136,6 @@ public class RxViewBinderTest {
         assertEquals("testString", testSubscriber.getOnNextEvents().get(0));
     }
 
-
     @Test
     public void testDoubleBind() throws Exception {
         binder.bind();

--- a/reark/src/test/java/io/reark/reark/utils/RxViewBinderTest.java
+++ b/reark/src/test/java/io/reark/reark/utils/RxViewBinderTest.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package io.reark.reark.utils;
 
 import android.support.annotation.NonNull;


### PR DESCRIPTION
Added license headers to files. When the project is used, quite many of the files will be copied to project as is, or at least used as a base. It's too easy to mix up licenses in this situation.

Also removed the "Created by" comments from files, since they show up as noise in javadocs.