### PR TITLE
Unit testing for store APIs

### DIFF
--- a/reark/src/androidTest/java/io/reark/reark/data/stores/SimpleMockContentProvider.java
+++ b/reark/src/androidTest/java/io/reark/reark/data/stores/SimpleMockContentProvider.java
@@ -1,0 +1,33 @@
+package io.reark.reark.data.stores;
+
+import android.database.Cursor;
+import android.net.Uri;
+import android.os.CancellationSignal;
+import android.support.annotation.Nullable;
+import android.test.mock.MockContentProvider;
+
+import java.util.HashMap;
+
+/**
+ * Mock content provider to act as the underlying provider for stores in unit tests.
+ */
+public class SimpleMockContentProvider extends MockContentProvider {
+    public static final String AUTHORITY = "test.authority";
+
+    private HashMap<Uri, Cursor> results = new HashMap<>();
+
+    public void addQueryResult(Uri uri, Cursor result) {
+        results.put(uri, result);
+    }
+
+    @Override
+    public Cursor query(Uri uri, String[] projection, String selection, String[] selectionArgs, String sortOrder) {
+        return results.get(uri);
+    }
+
+    @Nullable
+    @Override
+    public Cursor query(Uri uri, String[] projection, String selection, String[] selectionArgs, String sortOrder, CancellationSignal cancellationSignal) {
+        return results.get(uri);
+    }
+}

--- a/reark/src/androidTest/java/io/reark/reark/data/stores/SimpleMockContentProvider.java
+++ b/reark/src/androidTest/java/io/reark/reark/data/stores/SimpleMockContentProvider.java
@@ -1,6 +1,8 @@
 package io.reark.reark.data.stores;
 
+import android.content.ContentValues;
 import android.database.Cursor;
+import android.database.MatrixCursor;
 import android.net.Uri;
 import android.os.CancellationSignal;
 import android.support.annotation.Nullable;
@@ -13,21 +15,42 @@ import java.util.HashMap;
  */
 public class SimpleMockContentProvider extends MockContentProvider {
     public static final String AUTHORITY = "test.authority";
+    public static final String[] PROJECTION = new String[] { DataColumns.KEY, DataColumns.VALUE };
 
-    private HashMap<Uri, Cursor> results = new HashMap<>();
+    private HashMap<Uri, String> values = new HashMap<>();
 
-    public void addQueryResult(Uri uri, Cursor result) {
-        results.put(uri, result);
+    public interface DataColumns {
+        String KEY = "key";
+        String VALUE = "value";
+    }
+
+    @Override
+    public int update(Uri uri, ContentValues values, String selection, String[] selectionArgs) {
+        this.values.put(uri, values.getAsString(DataColumns.VALUE));
+        return 0;
+    }
+
+    @Override
+    public Uri insert(Uri uri, ContentValues values) {
+        this.values.put(uri, values.getAsString(DataColumns.VALUE));
+        return uri;
     }
 
     @Override
     public Cursor query(Uri uri, String[] projection, String selection, String[] selectionArgs, String sortOrder) {
-        return results.get(uri);
+        return getCursor(uri, projection);
     }
 
     @Nullable
     @Override
     public Cursor query(Uri uri, String[] projection, String selection, String[] selectionArgs, String sortOrder, CancellationSignal cancellationSignal) {
-        return results.get(uri);
+        return getCursor(uri, projection);
+    }
+
+    private Cursor getCursor(Uri uri, String[] projection) {
+        MatrixCursor cursor = new MatrixCursor(projection);
+        String[] result = { uri.getLastPathSegment(), values.get(uri) };
+        cursor.addRow(result);
+        return cursor;
     }
 }

--- a/reark/src/androidTest/java/io/reark/reark/data/stores/SimpleMockContentProvider.java
+++ b/reark/src/androidTest/java/io/reark/reark/data/stores/SimpleMockContentProvider.java
@@ -5,19 +5,19 @@ import android.database.Cursor;
 import android.database.MatrixCursor;
 import android.net.Uri;
 import android.os.CancellationSignal;
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.test.mock.MockContentProvider;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 
 /**
  * Mock content provider to act as the underlying provider for stores in unit tests.
  */
 public class SimpleMockContentProvider extends MockContentProvider {
-    public static final String AUTHORITY = "test.authority";
-    public static final String[] PROJECTION = new String[] { DataColumns.KEY, DataColumns.VALUE };
 
-    private HashMap<Uri, String> values = new HashMap<>();
+    // LinkedHashMap keeps the insertion order for more straightforward testing
+    private LinkedHashMap<Uri, String> values = new LinkedHashMap<>();
 
     public interface DataColumns {
         String KEY = "key";
@@ -25,14 +25,13 @@ public class SimpleMockContentProvider extends MockContentProvider {
     }
 
     @Override
-    public int update(Uri uri, ContentValues values, String selection, String[] selectionArgs) {
-        this.values.put(uri, values.getAsString(DataColumns.VALUE));
+    public int update(Uri uri, ContentValues contentValues, String selection, String[] selectionArgs) {
         return 0;
     }
 
     @Override
-    public Uri insert(Uri uri, ContentValues values) {
-        this.values.put(uri, values.getAsString(DataColumns.VALUE));
+    public Uri insert(Uri uri, ContentValues contentValues) {
+        values.put(uri, contentValues.getAsString(DataColumns.VALUE));
         return uri;
     }
 
@@ -43,14 +42,25 @@ public class SimpleMockContentProvider extends MockContentProvider {
 
     @Nullable
     @Override
-    public Cursor query(Uri uri, String[] projection, String selection, String[] selectionArgs, String sortOrder, CancellationSignal cancellationSignal) {
+    public Cursor query(@NonNull Uri uri, String[] projection, String selection, String[] selectionArgs,
+                        String sortOrder, CancellationSignal cancellationSignal) {
         return getCursor(uri, projection);
     }
 
+    // Crude imitation of the behavior of SQL content provider
     private Cursor getCursor(Uri uri, String[] projection) {
         MatrixCursor cursor = new MatrixCursor(projection);
-        String[] result = { uri.getLastPathSegment(), values.get(uri) };
-        cursor.addRow(result);
+
+        if (values.containsKey(uri)) {
+            String[] result = { uri.getLastPathSegment(), values.get(uri) };
+            cursor.addRow(result);
+        } else if (uri.getLastPathSegment().equals("0")) {
+            for (Uri key : values.keySet()) {
+                String[] result = { key.getLastPathSegment(), values.get(key) };
+                cursor.addRow(result);
+            }
+        }
+
         return cursor;
     }
 }

--- a/reark/src/androidTest/java/io/reark/reark/data/stores/SingleItemContentProviderStoreTest.java
+++ b/reark/src/androidTest/java/io/reark/reark/data/stores/SingleItemContentProviderStoreTest.java
@@ -1,0 +1,104 @@
+package io.reark.reark.data.stores;
+
+import android.content.ContentResolver;
+import android.content.ContentValues;
+import android.database.Cursor;
+import android.database.MatrixCursor;
+import android.net.Uri;
+import android.support.annotation.NonNull;
+import android.test.ProviderTestCase2;
+
+import io.reark.reark.data.store.SingleItemContentProviderStore;
+import io.reark.reark.utils.Log;
+import io.reark.reark.utils.Preconditions;
+
+public class SingleItemContentProviderStoreTest extends ProviderTestCase2<SimpleMockContentProvider> {
+
+    private static final String AUTHORITY = SimpleMockContentProvider.AUTHORITY;
+    private static final Uri AUTHORITY_URI = Uri.parse("content://" + AUTHORITY);
+    private static final Uri DATA_URI = Uri.withAppendedPath(AUTHORITY_URI, "testPath");
+    private static final String[] PROJECTION = new String[] { DataColumns.KEY, DataColumns.VALUE };
+
+    public SingleItemContentProviderStoreTest() {
+        super(SimpleMockContentProvider.class, SimpleMockContentProvider.AUTHORITY);
+    }
+
+    public interface DataColumns {
+        String KEY = "key";
+        String VALUE = "value";
+    }
+
+    public void testSomething() {
+        // ARRANGE
+        MatrixCursor cursor = new MatrixCursor(PROJECTION);
+        String[] exampleData = { "1001", "parsnip" };
+        cursor.addRow(exampleData);
+        getProvider().addQueryResult(DATA_URI, cursor);
+
+        // ACT
+        Cursor resultCursor = getProvider().query(DATA_URI, PROJECTION, null, null, null);
+
+        // ASSERT
+        assertEquals(1, resultCursor.getCount());
+    }
+
+    public class TestStore extends SingleItemContentProviderStore<String, Integer> {
+
+        public TestStore(@NonNull ContentResolver contentResolver) {
+            super(contentResolver);
+        }
+
+        @NonNull
+        @Override
+        public Uri getUriForId(@NonNull Integer id) {
+            return Uri.parse(getContentUri() + "/" + id);
+        }
+
+        @NonNull
+        @Override
+        protected Integer getIdFor(@NonNull String item) {
+            return item.hashCode();
+        }
+
+        @NonNull
+        @Override
+        public Uri getContentUri() {
+            return DATA_URI;
+        }
+
+        @NonNull
+        @Override
+        protected String[] getProjection() {
+            return PROJECTION;
+        }
+
+        @NonNull
+        @Override
+        protected String read(Cursor cursor) {
+            return cursor.getString(cursor.getColumnIndex(DataColumns.KEY));
+        }
+
+        @NonNull
+        @Override
+        protected ContentValues readRaw(Cursor cursor) {
+            final String value = cursor.getString(cursor.getColumnIndex(DataColumns.VALUE));
+            ContentValues contentValues = new ContentValues();
+            contentValues.put(DataColumns.VALUE, value);
+            return contentValues;
+        }
+
+        @NonNull
+        @Override
+        protected ContentValues getContentValuesForItem(String item) {
+            ContentValues contentValues = new ContentValues();
+            contentValues.put(DataColumns.KEY, getIdFor(item));
+            contentValues.put(DataColumns.VALUE, item);
+            return contentValues;
+        }
+
+        @Override
+        protected boolean contentValuesEqual(ContentValues v1, ContentValues v2) {
+            return v1.getAsString(DataColumns.KEY).equals(v2.getAsString(DataColumns.KEY));
+        }
+    }
+}

--- a/reark/src/androidTest/java/io/reark/reark/data/stores/SingleItemContentProviderStoreTest.java
+++ b/reark/src/androidTest/java/io/reark/reark/data/stores/SingleItemContentProviderStoreTest.java
@@ -2,44 +2,79 @@ package io.reark.reark.data.stores;
 
 import android.content.ContentResolver;
 import android.content.ContentValues;
+import android.content.Context;
 import android.database.Cursor;
 import android.database.MatrixCursor;
 import android.net.Uri;
 import android.support.annotation.NonNull;
+import android.test.IsolatedContext;
 import android.test.ProviderTestCase2;
+import android.test.mock.MockContentResolver;
+
+import java.util.ArrayList;
 
 import io.reark.reark.data.store.SingleItemContentProviderStore;
 import io.reark.reark.utils.Log;
 import io.reark.reark.utils.Preconditions;
+import rx.functions.Action1;
+import rx.observers.TestSubscriber;
 
 public class SingleItemContentProviderStoreTest extends ProviderTestCase2<SimpleMockContentProvider> {
 
     private static final String AUTHORITY = SimpleMockContentProvider.AUTHORITY;
     private static final Uri AUTHORITY_URI = Uri.parse("content://" + AUTHORITY);
     private static final Uri DATA_URI = Uri.withAppendedPath(AUTHORITY_URI, "testPath");
-    private static final String[] PROJECTION = new String[] { DataColumns.KEY, DataColumns.VALUE };
 
-    public SingleItemContentProviderStoreTest() {
-        super(SimpleMockContentProvider.class, SimpleMockContentProvider.AUTHORITY);
-    }
+
+    private MockContentResolver resolver;
+    private Context context;
+    private TestStore store;
 
     public interface DataColumns {
         String KEY = "key";
         String VALUE = "value";
     }
 
-    public void testSomething() {
+    public SingleItemContentProviderStoreTest() {
+        super(SimpleMockContentProvider.class, SimpleMockContentProvider.AUTHORITY);
+    }
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+
+        resolver = getMockContentResolver();
+        store = new TestStore(resolver);
+
+        Action1<String> insert = value ->
+                SingleItemContentProviderStoreTest.this.getProvider().insert(
+                        store.getUriForId(store.getIdFor(value)),
+                        store.getContentValuesForItem(value));
+
+        // Prepare the mock content provider with values
+        insert.call("parsnip");
+        insert.call("lettuce");
+    }
+
+    @Override
+    public MockContentResolver getMockContentResolver() {
+        MockContentResolver resolver = new MockContentResolver();
+        resolver.addProvider(AUTHORITY, getProvider());
+        return resolver;
+    }
+
+    public void testGetOneWithData() {
         // ARRANGE
-        MatrixCursor cursor = new MatrixCursor(PROJECTION);
-        String[] exampleData = { "1001", "parsnip" };
-        cursor.addRow(exampleData);
-        getProvider().addQueryResult(DATA_URI, cursor);
+        TestSubscriber<String> testSubscriber = new TestSubscriber<>();
 
         // ACT
-        Cursor resultCursor = getProvider().query(DATA_URI, PROJECTION, null, null, null);
+        store.getOne(store.getIdFor("parsnip")).subscribe(testSubscriber);
 
         // ASSERT
-        assertEquals(1, resultCursor.getCount());
+        testSubscriber.awaitTerminalEvent();
+        testSubscriber.assertCompleted();
+        testSubscriber.assertNoErrors();
+        testSubscriber.assertReceivedOnNext(new ArrayList<String>(){{ add("parsnip"); }});
     }
 
     public class TestStore extends SingleItemContentProviderStore<String, Integer> {
@@ -69,13 +104,13 @@ public class SingleItemContentProviderStoreTest extends ProviderTestCase2<Simple
         @NonNull
         @Override
         protected String[] getProjection() {
-            return PROJECTION;
+            return SimpleMockContentProvider.PROJECTION;
         }
 
         @NonNull
         @Override
         protected String read(Cursor cursor) {
-            return cursor.getString(cursor.getColumnIndex(DataColumns.KEY));
+            return cursor.getString(cursor.getColumnIndex(DataColumns.VALUE));
         }
 
         @NonNull

--- a/reark/src/androidTest/java/io/reark/reark/data/stores/SingleItemContentProviderStoreTest.java
+++ b/reark/src/androidTest/java/io/reark/reark/data/stores/SingleItemContentProviderStoreTest.java
@@ -20,7 +20,7 @@ public class SingleItemContentProviderStoreTest extends ProviderTestCase2<Simple
 
     private static final String AUTHORITY = "test.authority";
     private static final Uri AUTHORITY_URI = Uri.parse("content://" + AUTHORITY);
-    private static final Uri DATA_URI = Uri.withAppendedPath(AUTHORITY_URI, "testPath");
+    private static final Uri CONTENT_URI = Uri.withAppendedPath(AUTHORITY_URI, "veggies");
     private static final String[] PROJECTION = new String[] { DataColumns.KEY, DataColumns.VALUE };
 
     private TestStore store;
@@ -36,7 +36,7 @@ public class SingleItemContentProviderStoreTest extends ProviderTestCase2<Simple
         store = new TestStore(getMockContentResolver());
 
         Action1<String> insert = value ->
-                SingleItemContentProviderStoreTest.this.getProvider().insert(
+                getProvider().insert(
                         store.getUriForId(store.getIdFor(value)),
                         store.getContentValuesForItem(value)
                 );
@@ -136,7 +136,6 @@ public class SingleItemContentProviderStoreTest extends ProviderTestCase2<Simple
     public void testGetEmptyStream() {
         // ARRANGE
         TestSubscriber<String> testSubscriber = new TestSubscriber<>();
-        List<String> expected = new ArrayList<>();
 
         // ACT
         store.getStream(store.getIdFor("bacon")).subscribe(testSubscriber);
@@ -145,7 +144,7 @@ public class SingleItemContentProviderStoreTest extends ProviderTestCase2<Simple
         testSubscriber.awaitTerminalEvent(50, TimeUnit.MILLISECONDS);
         testSubscriber.assertNotCompleted();
         testSubscriber.assertNoErrors();
-        testSubscriber.assertReceivedOnNext(expected);
+        testSubscriber.assertNoValues();
     }
 
     /**
@@ -160,7 +159,7 @@ public class SingleItemContentProviderStoreTest extends ProviderTestCase2<Simple
         @NonNull
         @Override
         public Uri getUriForId(@NonNull Integer id) {
-            return Uri.parse(getContentUri() + "/" + id);
+            return Uri.withAppendedPath(getContentUri(), String.valueOf(id));
         }
 
         @NonNull
@@ -172,7 +171,7 @@ public class SingleItemContentProviderStoreTest extends ProviderTestCase2<Simple
         @NonNull
         @Override
         public Uri getContentUri() {
-            return DATA_URI;
+            return CONTENT_URI;
         }
 
         @NonNull
@@ -207,7 +206,7 @@ public class SingleItemContentProviderStoreTest extends ProviderTestCase2<Simple
 
         @Override
         protected boolean contentValuesEqual(ContentValues v1, ContentValues v2) {
-            return v1.getAsString(DataColumns.KEY).equals(v2.getAsString(DataColumns.KEY));
+            return v1.getAsString(DataColumns.VALUE).equals(v2.getAsString(DataColumns.VALUE));
         }
     }
 }


### PR DESCRIPTION
Instrumentation unit tests for stores to test the APIs. This isn't exhaustive set of tests yet, as I'd like to hear if this makes sense. Some overhead code is needed for the mock content provider / resolver, and I'm not sure if it's possible to make our Travis to run instrumentation tests.

Also, perhaps it would be possible to just use a real SQL provider instead of this mocking?