### PR TITLE
Distinct search string to avoid repeating the search

### DIFF
--- a/app/src/main/java/io/reark/rxgithubapp/viewmodels/RepositoriesViewModel.java
+++ b/app/src/main/java/io/reark/rxgithubapp/viewmodels/RepositoriesViewModel.java
@@ -125,10 +125,11 @@ public class RepositoriesViewModel extends AbstractViewModel {
 
         ConnectableObservable<DataStreamNotification<GitHubRepositorySearch>> repositorySearchSource =
                 searchString
-                          .filter((string) -> string.length() > 2)
-                          .debounce(SEARCH_INPUT_DELAY, TimeUnit.MILLISECONDS)
-                          .switchMap(getGitHubRepositorySearch::call)
-                          .publish();
+                        .filter((string) -> string.length() > 2)
+                        .debounce(SEARCH_INPUT_DELAY, TimeUnit.MILLISECONDS)
+                        .distinctUntilChanged()
+                        .switchMap(getGitHubRepositorySearch::call)
+                        .publish();
 
         compositeSubscription.add(repositorySearchSource
                 .map(toProgressStatus())


### PR DESCRIPTION
Fixes two minor issues:
1) After fragment resuming (e.g. when returning to app from app switcher) the currently open search is resubmitted due to RepositoriesView.bindInternal() setting the current string again
2) If user changes the search and changes it back within the debounce time limit the search is still resubmitted, even though the effective search didn't change