### PR TITLE
Simplify the store interface by using types more instead of ContentValues

### DIFF
--- a/app/src/main/java/io/reark/rxgithubapp/data/stores/GitHubRepositorySearchStore.java
+++ b/app/src/main/java/io/reark/rxgithubapp/data/stores/GitHubRepositorySearchStore.java
@@ -84,23 +84,9 @@ public class GitHubRepositorySearchStore extends StoreBase<GitHubRepositorySearc
 
     @NonNull
     @Override
-    protected ContentValues readRaw(Cursor cursor) {
-        final String json = cursor.getString(cursor.getColumnIndex(GitHubRepositorySearchColumns.JSON));
-        ContentValues contentValues = new ContentValues();
-        contentValues.put(GitHubRepositorySearchColumns.JSON, json);
-        return contentValues;
-    }
-
-    @NonNull
-    @Override
     public Uri getUriForId(@NonNull String id) {
         Preconditions.checkNotNull(id, "Id cannot be null.");
 
         return GitHubProvider.GitHubRepositorySearches.withSearch(id);
-    }
-
-    @Override
-    protected boolean contentValuesEqual(@NonNull ContentValues v1, @NonNull ContentValues v2) {
-        return v1.getAsString(GitHubRepositorySearchColumns.JSON).equals(v2.getAsString(GitHubRepositorySearchColumns.JSON));
     }
 }

--- a/app/src/main/java/io/reark/rxgithubapp/data/stores/GitHubRepositoryStore.java
+++ b/app/src/main/java/io/reark/rxgithubapp/data/stores/GitHubRepositoryStore.java
@@ -86,31 +86,23 @@ public class GitHubRepositoryStore extends StoreBase<GitHubRepository, Integer> 
 
     @NonNull
     @Override
-    protected ContentValues readRaw(Cursor cursor) {
-        final String json = cursor.getString(cursor.getColumnIndex(JsonIdColumns.JSON));
-        ContentValues contentValues = new ContentValues();
-        contentValues.put(JsonIdColumns.JSON, json);
-        return contentValues;
-    }
-
-    @NonNull
-    @Override
     public Uri getUriForId(@NonNull Integer id) {
         Preconditions.checkNotNull(id, "Id cannot be null.");
 
         return GitHubProvider.GitHubRepositories.withId(id);
     }
 
-    @Override
-    protected boolean contentValuesEqual(@NonNull ContentValues v1, @NonNull ContentValues v2) {
-        return v1.getAsString(JsonIdColumns.JSON).equals(v2.getAsString(JsonIdColumns.JSON));
-    }
-
     @NonNull
     @Override
-    protected ContentValues mergeValues(@NonNull ContentValues v1, @NonNull ContentValues v2) {
-        GitHubRepository b1 = getGson().fromJson(v1.getAsString(GitHubRepositoryColumns.JSON), GitHubRepository.class);
-        GitHubRepository b2 = getGson().fromJson(v2.getAsString(GitHubRepositoryColumns.JSON), GitHubRepository.class);
-        return getContentValuesForItem(b1.overwrite(b2));
+    protected GitHubRepository mergeValues(@NonNull GitHubRepository v1, @NonNull GitHubRepository v2) {
+        // Creating a new object to avoid overwriting the passed argument
+        GitHubRepository newValue = new GitHubRepository(
+                v1.getId(),
+                v1.getName(),
+                v1.getStargazersCount(),
+                v1.getForksCount(),
+                v1.getOwner());
+
+        return newValue.overwrite(v2);
     }
 }

--- a/app/src/main/java/io/reark/rxgithubapp/data/stores/NetworkRequestStatusStore.java
+++ b/app/src/main/java/io/reark/rxgithubapp/data/stores/NetworkRequestStatusStore.java
@@ -93,23 +93,9 @@ public class NetworkRequestStatusStore extends StoreBase<NetworkRequestStatus, I
 
     @NonNull
     @Override
-    protected ContentValues readRaw(Cursor cursor) {
-        final String json = cursor.getString(cursor.getColumnIndex(JsonIdColumns.JSON));
-        ContentValues contentValues = new ContentValues();
-        contentValues.put(JsonIdColumns.JSON, json);
-        return contentValues;
-    }
-
-    @NonNull
-    @Override
     public Uri getUriForId(@NonNull Integer id) {
         Preconditions.checkNotNull(id, "Id cannot be null.");
 
         return GitHubProvider.NetworkRequestStatuses.withId(id);
-    }
-
-    @Override
-    protected boolean contentValuesEqual(@NonNull ContentValues v1, @NonNull ContentValues v2) {
-        return v1.getAsString(JsonIdColumns.JSON).equals(v2.getAsString(JsonIdColumns.JSON));
     }
 }

--- a/app/src/main/java/io/reark/rxgithubapp/data/stores/UserSettingsStore.java
+++ b/app/src/main/java/io/reark/rxgithubapp/data/stores/UserSettingsStore.java
@@ -97,23 +97,9 @@ public class UserSettingsStore extends StoreBase<UserSettings, Integer> {
 
     @NonNull
     @Override
-    protected ContentValues readRaw(Cursor cursor) {
-        final String json = cursor.getString(cursor.getColumnIndex(JsonIdColumns.JSON));
-        ContentValues contentValues = new ContentValues();
-        contentValues.put(JsonIdColumns.JSON, json);
-        return contentValues;
-    }
-
-    @NonNull
-    @Override
     public Uri getUriForId(@NonNull Integer id) {
         Preconditions.checkNotNull(id, "Id cannot be null.");
 
         return GitHubProvider.UserSettings.withId(id);
-    }
-
-    @Override
-    protected boolean contentValuesEqual(@NonNull ContentValues v1, @NonNull ContentValues v2) {
-        return v1.getAsString(JsonIdColumns.JSON).equals(v2.getAsString(JsonIdColumns.JSON));
     }
 }

--- a/app/src/main/java/io/reark/rxgithubapp/pojo/GitHubOwner.java
+++ b/app/src/main/java/io/reark/rxgithubapp/pojo/GitHubOwner.java
@@ -81,5 +81,4 @@ public class GitHubOwner {
         sb.append('}');
         return sb.toString();
     }
-
 }

--- a/app/src/main/java/io/reark/rxgithubapp/pojo/GitHubRepository.java
+++ b/app/src/main/java/io/reark/rxgithubapp/pojo/GitHubRepository.java
@@ -38,10 +38,10 @@ public class GitHubRepository extends OverwritablePojo<GitHubRepository> {
     private final String name;
 
     @SerializedName("stargazers_count")
-    private final int stargazersCount;
+    private int stargazersCount;
 
     @SerializedName("forks_count")
-    private final int forksCount;
+    private int forksCount;
 
     @Nullable
     @SerializedName("owner")

--- a/app/src/main/java/io/reark/rxgithubapp/pojo/GitHubRepositorySearch.java
+++ b/app/src/main/java/io/reark/rxgithubapp/pojo/GitHubRepositorySearch.java
@@ -43,4 +43,22 @@ public class GitHubRepositorySearch {
     public List<Integer> getItems() {
         return items;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        GitHubRepositorySearch that = (GitHubRepositorySearch) o;
+
+        if (search != null ? !search.equals(that.search) : that.search != null) return false;
+        return items != null ? items.equals(that.items) : that.items == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = search != null ? search.hashCode() : 0;
+        result = 31 * result + (items != null ? items.hashCode() : 0);
+        return result;
+    }
 }

--- a/app/src/main/java/io/reark/rxgithubapp/pojo/UserSettings.java
+++ b/app/src/main/java/io/reark/rxgithubapp/pojo/UserSettings.java
@@ -35,4 +35,19 @@ public class UserSettings {
     public int getSelectedRepositoryId() {
         return selectedRepositoryId;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        UserSettings that = (UserSettings) o;
+
+        return selectedRepositoryId == that.selectedRepositoryId;
+    }
+
+    @Override
+    public int hashCode() {
+        return selectedRepositoryId;
+    }
 }

--- a/reark/src/androidTest/java/io/reark/reark/data/stores/SingleItemContentProviderStoreTest.java
+++ b/reark/src/androidTest/java/io/reark/reark/data/stores/SingleItemContentProviderStoreTest.java
@@ -213,25 +213,11 @@ public class SingleItemContentProviderStoreTest extends ProviderTestCase2<Simple
 
         @NonNull
         @Override
-        protected ContentValues readRaw(Cursor cursor) {
-            final String value = cursor.getString(cursor.getColumnIndex(DataColumns.VALUE));
-            ContentValues contentValues = new ContentValues();
-            contentValues.put(DataColumns.VALUE, value);
-            return contentValues;
-        }
-
-        @NonNull
-        @Override
         protected ContentValues getContentValuesForItem(String item) {
             ContentValues contentValues = new ContentValues();
             contentValues.put(DataColumns.KEY, getIdFor(item));
             contentValues.put(DataColumns.VALUE, item);
             return contentValues;
-        }
-
-        @Override
-        protected boolean contentValuesEqual(ContentValues v1, ContentValues v2) {
-            return v1.getAsString(DataColumns.VALUE).equals(v2.getAsString(DataColumns.VALUE));
         }
     }
 }

--- a/reark/src/main/java/io/reark/reark/data/store/ContentProviderStore.java
+++ b/reark/src/main/java/io/reark/reark/data/store/ContentProviderStore.java
@@ -82,20 +82,20 @@ public abstract class ContentProviderStore<T> {
                 });
     }
 
-    private static <T> void updateIfValueChanged(ContentProviderStore store, Pair<T, Uri> pair) {
+    private static <T> void updateIfValueChanged(ContentProviderStore<T> store, Pair<T, Uri> pair) {
         final Cursor cursor = store.contentResolver.query(pair.second, store.getProjection(), null, null, null);
-        ContentValues newValues = store.getContentValuesForItem(pair.first);
+        T newItem = pair.first;
         boolean valuesEqual = false;
 
         if (cursor != null) {
             if (cursor.moveToFirst()) {
-                ContentValues currentValues = store.readRaw(cursor);
-                valuesEqual = store.contentValuesEqual(currentValues, newValues);
+                T currentItem = store.read(cursor);
+                valuesEqual = newItem.equals(currentItem);
 
                 if (!valuesEqual) {
                     Log.v(TAG, "Merging values at " + pair.second);
-                    newValues = store.mergeValues(currentValues, newValues);
-                    valuesEqual = store.contentValuesEqual(currentValues, newValues);
+                    newItem = store.mergeValues(currentItem, newItem);
+                    valuesEqual = newItem.equals(currentItem);
                 }
             }
             cursor.close();
@@ -103,8 +103,13 @@ public abstract class ContentProviderStore<T> {
 
         if (valuesEqual) {
             Log.v(TAG, "Data already up to date at " + pair.second);
-        } else if (store.contentResolver.update(pair.second, newValues, null, null) == 0) {
-            final Uri resultUri = store.contentResolver.insert(pair.second, newValues);
+            return;
+        }
+
+        final ContentValues contentValues = store.getContentValuesForItem(newItem);
+
+        if (store.contentResolver.update(pair.second, contentValues, null, null) == 0) {
+            final Uri resultUri = store.contentResolver.insert(pair.second, contentValues);
             Log.v(TAG, "Inserted at " + resultUri);
         } else {
             Log.v(TAG, "Updated at " + pair.second);
@@ -180,15 +185,10 @@ public abstract class ContentProviderStore<T> {
     protected abstract T read(Cursor cursor);
 
     @NonNull
-    protected abstract ContentValues readRaw(Cursor cursor);
-
-    @NonNull
     protected abstract ContentValues getContentValuesForItem(T item);
 
-    protected abstract boolean contentValuesEqual(@NonNull ContentValues v1, @NonNull ContentValues v2);
-
     @NonNull
-    protected ContentValues mergeValues(@NonNull ContentValues v1, @NonNull ContentValues v2) {
+    protected T mergeValues(@NonNull T v1, @NonNull T v2) {
         return v2; // Default behavior is new values overriding
     }
 }


### PR DESCRIPTION
ContentProviderStore is using ContentValues in places where we could use the types instead. Changing to types allows us to remove two methods from the store interface. After this change all store objects are required to implement a valid equals() method, otherwise the persisted values won't be updated.