### PR TITLE
Fix widget not updating to changing values

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -35,7 +35,8 @@
                 android:resource="@xml/appwidget_info" />
         </receiver>
 
-        <service android:name=".widget.WidgetService" />
+        <service android:name=".widget.WidgetService"
+            android:process=":widgetservice" />
 
         <service android:name=".network.NetworkService"
             android:process=":networkservice" />

--- a/app/src/main/java/io/reark/rxgithubapp/RxGitHubApp.java
+++ b/app/src/main/java/io/reark/rxgithubapp/RxGitHubApp.java
@@ -26,14 +26,22 @@
 package io.reark.rxgithubapp;
 
 import android.app.Application;
+import android.appwidget.AppWidgetManager;
+import android.content.ComponentName;
+import android.content.Intent;
 import android.support.annotation.NonNull;
+
+import java.util.Arrays;
 
 import javax.inject.Inject;
 
+import io.reark.reark.utils.Log;
 import io.reark.rxgithubapp.injections.Graph;
 import io.reark.rxgithubapp.utils.ApplicationInstrumentation;
+import io.reark.rxgithubapp.widget.WidgetProvider;
 
 public class RxGitHubApp extends Application {
+    private static final String TAG = RxGitHubApp.class.getSimpleName();
 
     private static RxGitHubApp instance;
 
@@ -50,6 +58,8 @@ public class RxGitHubApp extends Application {
         getGraph().inject(this);
 
         instrumentation.init();
+
+        updateWidget();
     }
 
     @NonNull
@@ -62,4 +72,16 @@ public class RxGitHubApp extends Application {
         return mGraph;
     }
 
+    public void updateWidget() {
+        int widgetIds[] = AppWidgetManager
+                .getInstance(this)
+                .getAppWidgetIds(new ComponentName(this, WidgetProvider.class));
+
+        Log.d(TAG, "updateWidget(" + Arrays.toString(widgetIds) + ")");
+
+        Intent intent = new Intent(this, WidgetProvider.class);
+        intent.setAction(AppWidgetManager.ACTION_APPWIDGET_UPDATE);
+        intent.putExtra(AppWidgetManager.EXTRA_APPWIDGET_IDS, widgetIds);
+        sendBroadcast(intent);
+    }
 }

--- a/app/src/main/java/io/reark/rxgithubapp/network/NetworkService.java
+++ b/app/src/main/java/io/reark/rxgithubapp/network/NetworkService.java
@@ -50,13 +50,15 @@ public class NetworkService extends Service {
     @Override
     public int onStartCommand(Intent intent, int flags, int startId) {
         Log.d(TAG, "onStartCommand");
+        super.onStartCommand(intent, flags, startId);
+
         if (intent != null) {
             serviceDataLayer.processIntent(intent);
         } else {
             Log.d(TAG, "Intent was null, no action taken");
         }
 
-        return super.onStartCommand(intent, flags, startId);
+        return START_NOT_STICKY;
     }
 
     @Override

--- a/app/src/main/java/io/reark/rxgithubapp/widget/WidgetService.java
+++ b/app/src/main/java/io/reark/rxgithubapp/widget/WidgetService.java
@@ -34,8 +34,6 @@ import android.widget.RemoteViews;
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.request.target.AppWidgetTarget;
 
-import java.util.Arrays;
-
 import javax.inject.Inject;
 
 import io.reark.reark.utils.Log;

--- a/app/src/main/java/io/reark/rxgithubapp/widget/WidgetService.java
+++ b/app/src/main/java/io/reark/rxgithubapp/widget/WidgetService.java
@@ -34,6 +34,8 @@ import android.widget.RemoteViews;
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.request.target.AppWidgetTarget;
 
+import java.util.Arrays;
+
 import javax.inject.Inject;
 
 import io.reark.reark.utils.Log;
@@ -42,6 +44,7 @@ import io.reark.rxgithubapp.RxGitHubApp;
 import io.reark.rxgithubapp.data.DataLayer;
 import io.reark.rxgithubapp.pojo.UserSettings;
 import rx.android.schedulers.AndroidSchedulers;
+import rx.schedulers.Schedulers;
 import rx.subscriptions.CompositeSubscription;
 
 public class WidgetService extends Service {
@@ -53,7 +56,7 @@ public class WidgetService extends Service {
     @Inject
     DataLayer.FetchAndGetGitHubRepository fetchAndGetGitHubRepository;
 
-    private CompositeSubscription subscriptions;
+    private final CompositeSubscription subscriptions = new CompositeSubscription();
 
     public WidgetService() {
         RxGitHubApp.getInstance().getGraph().inject(this);
@@ -61,6 +64,8 @@ public class WidgetService extends Service {
 
     @Override
     public int onStartCommand(Intent intent, int flags, int startId) {
+        super.onStartCommand(intent, flags, startId);
+
         if (intent != null && intent.hasExtra("widgetId")) {
             final int appWidgetId = intent.getIntExtra("widgetId", 0);
             Log.d(TAG, "onStartCommand(" + appWidgetId + ")");
@@ -68,7 +73,8 @@ public class WidgetService extends Service {
         } else {
             Log.e(TAG, "onStartCommand(<no widgetId>)");
         }
-        return super.onStartCommand(intent, flags, startId);
+
+        return START_NOT_STICKY;
     }
 
     private void updateWidget(final int widgetId) {
@@ -80,11 +86,13 @@ public class WidgetService extends Service {
         appWidgetManager.updateAppWidget(widgetId, remoteViews);
 
         clearSubscriptions();
+
         subscriptions.add(
                 getUserSettings.call()
                         .map(UserSettings::getSelectedRepositoryId)
+                        .doOnNext(repositoryId -> Log.d(TAG, "Changed repository to " + repositoryId))
                         .switchMap(fetchAndGetGitHubRepository::call)
-                        .subscribeOn(AndroidSchedulers.mainThread())
+                        .subscribeOn(Schedulers.io())
                         .observeOn(AndroidSchedulers.mainThread())
                         .subscribe(repository -> {
                             remoteViews.setTextViewText(R.id.widget_layout_title, repository.getName());
@@ -103,15 +111,11 @@ public class WidgetService extends Service {
                                  .fitCenter()
                                  .into(widgetTarget);
                             appWidgetManager.updateAppWidget(widgetId, remoteViews);
-                        })
-        );
+                        }));
     }
 
     private void clearSubscriptions() {
-        if (subscriptions != null) {
-            subscriptions.clear();
-        }
-        subscriptions = new CompositeSubscription();
+        subscriptions.clear();
     }
 
     @Override


### PR DESCRIPTION
If the application is killed and restarted, the widget stops updating. Reason for this is that our services are sticky, so they are restarted soon after application is killed. However, because the WidgetService onStartCommand doesn't come from WidgetProvider, we are missing the widget id and can't thus update the data. Later when the main app is restarted it doesn't trigger widget update, and thus the widget isn't updated until hitting the update period in appwidget_info.xml.

This PR fixes the issue by changing the services to non-sticky. We can do this since the data won't anyway update unless the main app is running. Additionally we must trigger widget update when the app starts.

Also moved the widget service to a separate process just for easier observation.