### PR TITLE
Remove unnecessary app label from the manifest

### DIFF
--- a/reark/src/main/AndroidManifest.xml
+++ b/reark/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="io.reark.library">
 
-    <application android:allowBackup="true" android:label="@string/app_name">
+    <application android:allowBackup="true">
 
     </application>
 

--- a/reark/src/main/res/values/strings.xml
+++ b/reark/src/main/res/values/strings.xml
@@ -1,3 +1,0 @@
-<resources>
-    <string name="app_name">Library</string>
-</resources>


### PR DESCRIPTION
Remove unnecessary app label from the manifest because it caused some trouble in manifest merge when building project.

Also removed strings.xml from the library since it's not needed anymore.