### PR TITLE
Parallel data merges in data stores

### DIFF
--- a/reark/src/main/java/io/reark/reark/utils/LockObjectDealer.java
+++ b/reark/src/main/java/io/reark/reark/utils/LockObjectDealer.java
@@ -1,0 +1,72 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package io.reark.reark.utils;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Util class for providing objects to be used as synchronization locks. Equal objects will
+ * share the same lock object, so that it can be used to synchronize sections where simultaneous
+ * usage of two equal objects could cause concurrency issues.
+ */
+public class LockObjectDealer<T> {
+    private final Object locksEditLock = new Object();
+    private final Map<T, LockObjectHolder> locks = new HashMap<>();
+
+    private class LockObjectHolder {
+        public final Object lockObject = new Object();
+        public int counter = 1;
+    }
+
+    public void createLock(T object) {
+        synchronized (locksEditLock) {
+            if (!locks.containsKey(object)) {
+                locks.put(object, new LockObjectHolder());
+            } else {
+                updateLockCounter(object, 1);
+            }
+        }
+    }
+
+    public Object getLock(T object) {
+        return locks.get(object).lockObject;
+    }
+
+    public void freeLock(T object) {
+        synchronized (locksEditLock) {
+            if (locks.get(object).counter == 1) {
+                locks.remove(object);
+            } else {
+                updateLockCounter(object, -1);
+            }
+        }
+    }
+
+    private void updateLockCounter(T object, int diff) {
+        locks.get(object).counter += diff;
+    }
+}

--- a/reark/src/test/java/io/reark/reark/utils/LockObjectDealerTest.java
+++ b/reark/src/test/java/io/reark/reark/utils/LockObjectDealerTest.java
@@ -1,0 +1,112 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2016 reark project contributors
+ *
+ * https://github.com/reark/reark/graphs/contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package io.reark.reark.utils;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class LockObjectDealerTest {
+
+    @Test
+    public void testSameKeyGivesSameLockObject() {
+        LockObjectDealer<String> locker = new LockObjectDealer<>();
+
+        locker.createLock("foo");
+        Object obj1 = locker.getLock("foo");
+        Object obj2 = locker.getLock("foo");
+
+        assertTrue(obj1 == obj2);
+    }
+
+    @Test
+    public void testDifferentKeyGivesDifferentLockObjects() {
+        LockObjectDealer<String> locker = new LockObjectDealer<>();
+
+        locker.createLock("foo");
+        locker.createLock("bar");
+        Object obj1 = locker.getLock("foo");
+        Object obj2 = locker.getLock("bar");
+
+        assertFalse(obj1 == obj2);
+    }
+
+    @Test
+    public void testNewLockObjectAfterFreeing() {
+        LockObjectDealer<String> locker = new LockObjectDealer<>();
+
+        locker.createLock("foo");
+        Object obj1 = locker.getLock("foo");
+        locker.freeLock("foo");
+        locker.createLock("foo");
+        Object obj2 = locker.getLock("foo");
+
+        assertFalse(obj1 == obj2);
+    }
+
+    @Test
+    public void testCreatesNeedEqualNumberOfFrees() {
+        LockObjectDealer<String> locker = new LockObjectDealer<>();
+
+        locker.createLock("foo");
+        locker.createLock("foo");
+        Object obj1 = locker.getLock("foo");
+        locker.freeLock("foo");
+        Object obj2 = locker.getLock("foo");
+        locker.freeLock("foo");
+        locker.createLock("foo");
+        Object obj3 = locker.getLock("foo");
+
+        assertTrue(obj1 == obj2);
+        assertFalse(obj2 == obj3);
+    }
+
+    @Test(expected=NullPointerException.class)
+    public void testCantGetBeforeCreating() {
+        LockObjectDealer<String> locker = new LockObjectDealer<>();
+
+        locker.getLock("foo");
+    }
+
+    @Test(expected=NullPointerException.class)
+    public void testCantGetAfterFreeing() {
+        LockObjectDealer<String> locker = new LockObjectDealer<>();
+
+        locker.createLock("foo");
+        locker.freeLock("foo");
+        locker.getLock("foo");
+    }
+
+    @Test(expected=NullPointerException.class)
+    public void testCantFreeMoreThanCreated() {
+        LockObjectDealer<String> locker = new LockObjectDealer<>();
+
+        locker.createLock("foo");
+        locker.freeLock("foo");
+        locker.freeLock("foo");
+    }
+}


### PR DESCRIPTION
Stores were handling possible data races by executing only one put operation at a time. This causes insertions of larger data batches to take longer than really necessary.

Here we change the logic to support parallel insertions. Data races are handled by synchronizing the critical section per unique Uri, ensuring that two operations on one Uri can not enter the section simultaneously.

Improved use case: 1000 data update attempts go through read-compare-merge, but none of them changes data so zero database updates/insertions. Update execution time dropped by about 66% with this change in place, from 5.9s to 1.9s in my test phone.

I will later create an additional optimization for the case where we actually update the content.