### PR TITLE
Make decorateNetwork decorate client builder

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,3 +1,8 @@
+apply plugin: 'com.android.application'
+apply plugin: 'me.tatarka.retrolambda'
+apply plugin: 'com.neenbedankt.android-apt'
+apply plugin: 'spoon'
+
 buildscript {
     repositories {
         mavenCentral()
@@ -9,11 +14,6 @@ repositories {
     maven { url 'https://oss.sonatype.org/content/repositories/snapshots/' }
     mavenCentral()
 }
-
-apply plugin: 'com.android.application'
-apply plugin: 'me.tatarka.retrolambda'
-apply plugin: 'com.neenbedankt.android-apt'
-
 
 android {
     compileSdkVersion 24

--- a/app/src/androidTest/java/io/reark/rxgithubapp/advanced/activities/ChooseRepositoryActivityTest.java
+++ b/app/src/androidTest/java/io/reark/rxgithubapp/advanced/activities/ChooseRepositoryActivityTest.java
@@ -25,14 +25,14 @@
  */
 package io.reark.rxgithubapp.advanced.activities;
 
-import android.support.test.rule.ActivityTestRule;
-import android.support.test.runner.AndroidJUnit4;
-import android.test.suitebuilder.annotation.LargeTest;
-
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import android.support.test.rule.ActivityTestRule;
+import android.support.test.runner.AndroidJUnit4;
+import android.test.suitebuilder.annotation.LargeTest;
 
 import io.reark.rxgithubapp.R;
 

--- a/app/src/androidTest/java/io/reark/rxgithubapp/advanced/activities/MainActivityTest.java
+++ b/app/src/androidTest/java/io/reark/rxgithubapp/advanced/activities/MainActivityTest.java
@@ -25,14 +25,14 @@
  */
 package io.reark.rxgithubapp.advanced.activities;
 
-import android.support.test.rule.ActivityTestRule;
-import android.support.test.runner.AndroidJUnit4;
-import android.test.suitebuilder.annotation.LargeTest;
-
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import android.support.test.rule.ActivityTestRule;
+import android.support.test.runner.AndroidJUnit4;
+import android.test.suitebuilder.annotation.LargeTest;
 
 import io.reark.rxgithubapp.R;
 

--- a/app/src/androidTest/java/io/reark/rxgithubapp/advanced/data/stores/GitHubRepositoryStoreTest.java
+++ b/app/src/androidTest/java/io/reark/rxgithubapp/advanced/data/stores/GitHubRepositoryStoreTest.java
@@ -1,18 +1,18 @@
 package io.reark.rxgithubapp.advanced.data.stores;
 
-import android.content.pm.ProviderInfo;
-import android.support.annotation.NonNull;
-import android.support.test.InstrumentationRegistry;
-import android.support.test.runner.AndroidJUnit4;
-import android.test.ProviderTestCase2;
-import android.test.mock.MockContentResolver;
-
 import com.google.gson.Gson;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import android.content.pm.ProviderInfo;
+import android.support.annotation.NonNull;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.runner.AndroidJUnit4;
+import android.test.ProviderTestCase2;
+import android.test.mock.MockContentResolver;
 
 import java.util.concurrent.TimeUnit;
 

--- a/app/src/androidTest/java/io/reark/rxgithubapp/advanced/data/stores/cores/GitHubRepositoryStoreCoreTest.java
+++ b/app/src/androidTest/java/io/reark/rxgithubapp/advanced/data/stores/cores/GitHubRepositoryStoreCoreTest.java
@@ -1,5 +1,12 @@
 package io.reark.rxgithubapp.advanced.data.stores.cores;
 
+import com.google.gson.Gson;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
 import android.content.ContentProvider;
 import android.content.pm.ProviderInfo;
 import android.support.annotation.NonNull;
@@ -7,13 +14,6 @@ import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
 import android.test.ProviderTestCase2;
 import android.test.mock.MockContentResolver;
-
-import com.google.gson.Gson;
-
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 
 import java.util.concurrent.TimeUnit;
 

--- a/app/src/main/java/io/reark/rxgithubapp/advanced/data/schematicProvider/GitHubProvider.java
+++ b/app/src/main/java/io/reark/rxgithubapp/advanced/data/schematicProvider/GitHubProvider.java
@@ -25,14 +25,14 @@
  */
 package io.reark.rxgithubapp.advanced.data.schematicProvider;
 
-import android.net.Uri;
-import android.net.Uri.Builder;
-import android.support.annotation.NonNull;
-
 import net.simonvt.schematic.annotation.ContentProvider;
 import net.simonvt.schematic.annotation.ContentUri;
 import net.simonvt.schematic.annotation.InexactContentUri;
 import net.simonvt.schematic.annotation.TableEndpoint;
+
+import android.net.Uri;
+import android.net.Uri.Builder;
+import android.support.annotation.NonNull;
 
 import static io.reark.reark.utils.Preconditions.get;
 

--- a/app/src/main/java/io/reark/rxgithubapp/advanced/data/stores/GitHubRepositorySearchStore.java
+++ b/app/src/main/java/io/reark/rxgithubapp/advanced/data/stores/GitHubRepositorySearchStore.java
@@ -25,10 +25,10 @@
  */
 package io.reark.rxgithubapp.advanced.data.stores;
 
+import com.google.gson.Gson;
+
 import android.content.ContentResolver;
 import android.support.annotation.NonNull;
-
-import com.google.gson.Gson;
 
 import io.reark.reark.data.stores.DefaultStore;
 import io.reark.rxgithubapp.advanced.data.stores.cores.GitHubRepositorySearchStoreCore;

--- a/app/src/main/java/io/reark/rxgithubapp/advanced/data/stores/GitHubRepositoryStore.java
+++ b/app/src/main/java/io/reark/rxgithubapp/advanced/data/stores/GitHubRepositoryStore.java
@@ -25,10 +25,10 @@
  */
 package io.reark.rxgithubapp.advanced.data.stores;
 
+import com.google.gson.Gson;
+
 import android.content.ContentResolver;
 import android.support.annotation.NonNull;
-
-import com.google.gson.Gson;
 
 import io.reark.reark.data.stores.DefaultStore;
 import io.reark.rxgithubapp.advanced.data.stores.cores.GitHubRepositoryStoreCore;

--- a/app/src/main/java/io/reark/rxgithubapp/advanced/data/stores/NetworkRequestStatusStore.java
+++ b/app/src/main/java/io/reark/rxgithubapp/advanced/data/stores/NetworkRequestStatusStore.java
@@ -25,10 +25,10 @@
  */
 package io.reark.rxgithubapp.advanced.data.stores;
 
+import com.google.gson.Gson;
+
 import android.content.ContentResolver;
 import android.support.annotation.NonNull;
-
-import com.google.gson.Gson;
 
 import io.reark.reark.data.stores.DefaultStore;
 import io.reark.reark.pojo.NetworkRequestStatus;

--- a/app/src/main/java/io/reark/rxgithubapp/advanced/data/stores/StoreModule.java
+++ b/app/src/main/java/io/reark/rxgithubapp/advanced/data/stores/StoreModule.java
@@ -25,9 +25,9 @@
  */
 package io.reark.rxgithubapp.advanced.data.stores;
 
-import android.content.ContentResolver;
-
 import com.google.gson.Gson;
+
+import android.content.ContentResolver;
 
 import javax.inject.Singleton;
 

--- a/app/src/main/java/io/reark/rxgithubapp/advanced/data/stores/UserSettingsStore.java
+++ b/app/src/main/java/io/reark/rxgithubapp/advanced/data/stores/UserSettingsStore.java
@@ -25,10 +25,10 @@
  */
 package io.reark.rxgithubapp.advanced.data.stores;
 
+import com.google.gson.Gson;
+
 import android.content.ContentResolver;
 import android.support.annotation.NonNull;
-
-import com.google.gson.Gson;
 
 import io.reark.reark.data.stores.DefaultStore;
 import io.reark.rxgithubapp.advanced.data.stores.cores.UserSettingsStoreCore;

--- a/app/src/main/java/io/reark/rxgithubapp/advanced/data/stores/cores/GitHubRepositorySearchStoreCore.java
+++ b/app/src/main/java/io/reark/rxgithubapp/advanced/data/stores/cores/GitHubRepositorySearchStoreCore.java
@@ -25,13 +25,13 @@
  */
 package io.reark.rxgithubapp.advanced.data.stores.cores;
 
+import com.google.gson.Gson;
+
 import android.content.ContentResolver;
 import android.content.ContentValues;
 import android.database.Cursor;
 import android.net.Uri;
 import android.support.annotation.NonNull;
-
-import com.google.gson.Gson;
 
 import io.reark.reark.data.stores.cores.ContentProviderStoreCore;
 import io.reark.reark.utils.Preconditions;

--- a/app/src/main/java/io/reark/rxgithubapp/advanced/data/stores/cores/GitHubRepositoryStoreCore.java
+++ b/app/src/main/java/io/reark/rxgithubapp/advanced/data/stores/cores/GitHubRepositoryStoreCore.java
@@ -25,13 +25,13 @@
  */
 package io.reark.rxgithubapp.advanced.data.stores.cores;
 
+import com.google.gson.Gson;
+
 import android.content.ContentResolver;
 import android.content.ContentValues;
 import android.database.Cursor;
 import android.net.Uri;
 import android.support.annotation.NonNull;
-
-import com.google.gson.Gson;
 
 import io.reark.reark.data.stores.cores.ContentProviderStoreCore;
 import io.reark.reark.utils.Preconditions;

--- a/app/src/main/java/io/reark/rxgithubapp/advanced/data/stores/cores/NetworkRequestStatusStoreCore.java
+++ b/app/src/main/java/io/reark/rxgithubapp/advanced/data/stores/cores/NetworkRequestStatusStoreCore.java
@@ -25,13 +25,13 @@
  */
 package io.reark.rxgithubapp.advanced.data.stores.cores;
 
+import com.google.gson.Gson;
+
 import android.content.ContentResolver;
 import android.content.ContentValues;
 import android.database.Cursor;
 import android.net.Uri;
 import android.support.annotation.NonNull;
-
-import com.google.gson.Gson;
 
 import io.reark.reark.data.stores.cores.ContentProviderStoreCore;
 import io.reark.reark.pojo.NetworkRequestStatus;

--- a/app/src/main/java/io/reark/rxgithubapp/advanced/data/stores/cores/UserSettingsStoreCore.java
+++ b/app/src/main/java/io/reark/rxgithubapp/advanced/data/stores/cores/UserSettingsStoreCore.java
@@ -25,13 +25,13 @@
  */
 package io.reark.rxgithubapp.advanced.data.stores.cores;
 
+import com.google.gson.Gson;
+
 import android.content.ContentResolver;
 import android.content.ContentValues;
 import android.database.Cursor;
 import android.net.Uri;
 import android.support.annotation.NonNull;
-
-import com.google.gson.Gson;
 
 import io.reark.reark.data.stores.cores.ContentProviderStoreCore;
 import io.reark.reark.utils.Preconditions;

--- a/app/src/main/java/io/reark/rxgithubapp/advanced/widget/WidgetService.java
+++ b/app/src/main/java/io/reark/rxgithubapp/advanced/widget/WidgetService.java
@@ -25,14 +25,14 @@
  */
 package io.reark.rxgithubapp.advanced.widget;
 
+import com.bumptech.glide.Glide;
+import com.bumptech.glide.request.target.AppWidgetTarget;
+
 import android.app.Service;
 import android.appwidget.AppWidgetManager;
 import android.content.Intent;
 import android.os.IBinder;
 import android.widget.RemoteViews;
-
-import com.bumptech.glide.Glide;
-import com.bumptech.glide.request.target.AppWidgetTarget;
 
 import javax.inject.Inject;
 

--- a/appshared/build.gradle
+++ b/appshared/build.gradle
@@ -40,7 +40,6 @@ dependencies {
     compile 'com.squareup.retrofit2:retrofit:2.0.0'
     compile 'com.squareup.retrofit2:adapter-rxjava:2.0.0'
     compile 'com.squareup.retrofit2:converter-gson:2.0.0'
-    compile 'com.github.bumptech.glide:glide:3.7.0'
     compile 'com.android.support:appcompat-v7:24.2.1'
 
     // RxJava
@@ -62,6 +61,7 @@ dependencies {
 
     // Unit test build
     testCompile 'junit:junit:4.12'
+    testCompile 'org.assertj:assertj-core:1.7.1'
     testCompile 'org.mockito:mockito-core:1.10.19'
     testCompile 'org.powermock:powermock-api-mockito:1.6.4'
     testCompile 'org.powermock:powermock-module-junit4:1.6.4'

--- a/appshared/proguard-rules.pro
+++ b/appshared/proguard-rules.pro
@@ -46,7 +46,6 @@
    long consumerIndex;
 }
 
-
 # For retrolambda
 -dontwarn java.lang.invoke.*
 

--- a/appshared/src/debug/java/io/reark/rxgithubapp/shared/injections/InstrumentationModule.java
+++ b/appshared/src/debug/java/io/reark/rxgithubapp/shared/injections/InstrumentationModule.java
@@ -25,10 +25,13 @@
  */
 package io.reark.rxgithubapp.shared.injections;
 
+import com.facebook.stetho.okhttp3.StethoInterceptor;
+
 import android.app.Application;
 import android.content.Context;
-import com.facebook.stetho.okhttp3.StethoInterceptor;
+
 import javax.inject.Singleton;
+
 import dagger.Module;
 import dagger.Provides;
 import io.reark.rxgithubapp.shared.network.NetworkInstrumentation;
@@ -64,7 +67,7 @@ public class InstrumentationModule {
 
     @Provides
     @Singleton
-    public NetworkInstrumentation<OkHttpClient> providesNetworkInstrumentation(StethoInstrumentation instrumentation) {
+    public NetworkInstrumentation<OkHttpClient.Builder> providesNetworkInstrumentation(StethoInstrumentation instrumentation) {
         return instrumentation;
     }
 

--- a/appshared/src/debug/java/io/reark/rxgithubapp/shared/utils/LeakCanaryTracing.java
+++ b/appshared/src/debug/java/io/reark/rxgithubapp/shared/utils/LeakCanaryTracing.java
@@ -25,10 +25,10 @@
  */
 package io.reark.rxgithubapp.shared.utils;
 
-import android.app.Application;
-
 import com.squareup.leakcanary.LeakCanary;
 import com.squareup.leakcanary.RefWatcher;
+
+import android.app.Application;
 
 public class LeakCanaryTracing implements LeakTracing {
 

--- a/appshared/src/debug/java/io/reark/rxgithubapp/shared/utils/StethoInstrumentation.java
+++ b/appshared/src/debug/java/io/reark/rxgithubapp/shared/utils/StethoInstrumentation.java
@@ -28,18 +28,18 @@ package io.reark.rxgithubapp.shared.utils;
 import android.content.Context;
 import android.support.annotation.NonNull;
 import android.support.annotation.VisibleForTesting;
-import io.reark.reark.utils.Preconditions;
+
 import io.reark.rxgithubapp.shared.network.NetworkInstrumentation;
 import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
+
 import static com.facebook.stetho.Stetho.defaultDumperPluginsProvider;
 import static com.facebook.stetho.Stetho.defaultInspectorModulesProvider;
 import static com.facebook.stetho.Stetho.initialize;
 import static com.facebook.stetho.Stetho.newInitializerBuilder;
-import static io.reark.reark.utils.Preconditions.checkNotNull;
 import static io.reark.reark.utils.Preconditions.get;
 
-public class StethoInstrumentation implements NetworkInstrumentation<OkHttpClient> {
+public class StethoInstrumentation implements NetworkInstrumentation<OkHttpClient.Builder> {
 
     @NonNull
     private final Context context;
@@ -47,13 +47,10 @@ public class StethoInstrumentation implements NetworkInstrumentation<OkHttpClien
     @NonNull
     private final Interceptor interceptor;
 
-    public StethoInstrumentation(@NonNull Context context,
-                                 @NonNull Interceptor interceptor) {
-        Preconditions.checkNotNull(context, "Context cannot be null.");
-        Preconditions.checkNotNull(interceptor, "Interceptor cannot be null.");
-
-        this.context = context;
-        this.interceptor = interceptor;
+    public StethoInstrumentation(@NonNull final Context context,
+                                 @NonNull final Interceptor interceptor) {
+        this.context = get(context);
+        this.interceptor = get(interceptor);
     }
 
     @Override
@@ -72,8 +69,7 @@ public class StethoInstrumentation implements NetworkInstrumentation<OkHttpClien
 
     @Override
     @NonNull
-    public OkHttpClient decorateNetwork(@NonNull final OkHttpClient httpClient) {
-        Preconditions.checkNotNull(httpClient, "Http Client cannot be null.");
-        return httpClient.newBuilder().addNetworkInterceptor(interceptor).build();
+    public OkHttpClient.Builder decorateNetwork(@NonNull final OkHttpClient.Builder clientBuilder) {
+        return get(clientBuilder).addNetworkInterceptor(interceptor);
     }
 }

--- a/appshared/src/main/java/io/reark/rxgithubapp/shared/glide/NullTarget.java
+++ b/appshared/src/main/java/io/reark/rxgithubapp/shared/glide/NullTarget.java
@@ -25,13 +25,13 @@
  */
 package io.reark.rxgithubapp.shared.glide;
 
-import android.graphics.drawable.Drawable;
-import android.support.annotation.Nullable;
-
 import com.bumptech.glide.request.Request;
 import com.bumptech.glide.request.animation.GlideAnimation;
 import com.bumptech.glide.request.target.SizeReadyCallback;
 import com.bumptech.glide.request.target.Target;
+
+import android.graphics.drawable.Drawable;
+import android.support.annotation.Nullable;
 
 public class NullTarget<T> implements Target<T> {
 

--- a/appshared/src/main/java/io/reark/rxgithubapp/shared/glide/SerialTarget.java
+++ b/appshared/src/main/java/io/reark/rxgithubapp/shared/glide/SerialTarget.java
@@ -25,13 +25,13 @@
  */
 package io.reark.rxgithubapp.shared.glide;
 
-import android.graphics.drawable.Drawable;
-import android.support.annotation.NonNull;
-
 import com.bumptech.glide.request.Request;
 import com.bumptech.glide.request.animation.GlideAnimation;
 import com.bumptech.glide.request.target.SizeReadyCallback;
 import com.bumptech.glide.request.target.Target;
+
+import android.graphics.drawable.Drawable;
+import android.support.annotation.NonNull;
 
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 

--- a/appshared/src/main/java/io/reark/rxgithubapp/shared/network/GitHubService.java
+++ b/appshared/src/main/java/io/reark/rxgithubapp/shared/network/GitHubService.java
@@ -29,11 +29,11 @@ import android.net.Uri;
 
 import java.util.Map;
 
+import io.reark.rxgithubapp.shared.pojo.GitHubRepository;
+import io.reark.rxgithubapp.shared.pojo.GitHubRepositorySearchResults;
 import retrofit2.http.GET;
 import retrofit2.http.Path;
 import retrofit2.http.QueryMap;
-import io.reark.rxgithubapp.shared.pojo.GitHubRepository;
-import io.reark.rxgithubapp.shared.pojo.GitHubRepositorySearchResults;
 import rx.Observable;
 
 public interface GitHubService {

--- a/appshared/src/main/java/io/reark/rxgithubapp/shared/network/NetworkApi.java
+++ b/appshared/src/main/java/io/reark/rxgithubapp/shared/network/NetworkApi.java
@@ -26,9 +26,10 @@
 package io.reark.rxgithubapp.shared.network;
 
 import android.support.annotation.NonNull;
+
 import java.util.List;
 import java.util.Map;
-import io.reark.reark.utils.Preconditions;
+
 import io.reark.rxgithubapp.shared.pojo.GitHubRepository;
 import io.reark.rxgithubapp.shared.pojo.GitHubRepositorySearchResults;
 import okhttp3.OkHttpClient;
@@ -44,8 +45,8 @@ public class NetworkApi {
     @NonNull
     private final GitHubService gitHubService;
 
-    public NetworkApi(@NonNull OkHttpClient client) {
-        Preconditions.checkNotNull(client, "Client cannot be null.");
+    public NetworkApi(@NonNull final OkHttpClient client) {
+        checkNotNull(client, "Client cannot be null.");
 
         Retrofit retrofit = new Retrofit.Builder()
                 .addCallAdapterFactory(RxJavaCallAdapterFactory.create())
@@ -53,6 +54,7 @@ public class NetworkApi {
                 .baseUrl("https://api.github.com")
                 .client(client)
                 .build();
+
         gitHubService = retrofit.create(GitHubService.class);
     }
 

--- a/appshared/src/main/java/io/reark/rxgithubapp/shared/network/NetworkModule.java
+++ b/appshared/src/main/java/io/reark/rxgithubapp/shared/network/NetworkModule.java
@@ -26,7 +26,9 @@
 package io.reark.rxgithubapp.shared.network;
 
 import com.google.gson.Gson;
+
 import javax.inject.Singleton;
+
 import dagger.Module;
 import dagger.Provides;
 import okhttp3.OkHttpClient;
@@ -42,8 +44,11 @@ public final class NetworkModule {
 
     @Provides
     @Singleton
-    public OkHttpClient provideOkHttpClient(NetworkInstrumentation<OkHttpClient> networkInstrumentation) {
-        return networkInstrumentation.decorateNetwork(new OkHttpClient());
+    public OkHttpClient provideOkHttpClient(NetworkInstrumentation<OkHttpClient.Builder> networkInstrumentation) {
+        OkHttpClient.Builder clientBuilder = new OkHttpClient().newBuilder();
+        networkInstrumentation.decorateNetwork(clientBuilder);
+
+        return clientBuilder.build();
     }
 
     @Provides

--- a/appshared/src/main/java/io/reark/rxgithubapp/shared/pojo/GitHubOwner.java
+++ b/appshared/src/main/java/io/reark/rxgithubapp/shared/pojo/GitHubOwner.java
@@ -25,9 +25,9 @@
  */
 package io.reark.rxgithubapp.shared.pojo;
 
-import android.support.annotation.NonNull;
-
 import com.google.gson.annotations.SerializedName;
+
+import android.support.annotation.NonNull;
 
 import static io.reark.reark.utils.Preconditions.get;
 

--- a/appshared/src/main/java/io/reark/rxgithubapp/shared/pojo/GitHubRepository.java
+++ b/appshared/src/main/java/io/reark/rxgithubapp/shared/pojo/GitHubRepository.java
@@ -25,9 +25,9 @@
  */
 package io.reark.rxgithubapp.shared.pojo;
 
-import android.support.annotation.NonNull;
-
 import com.google.gson.annotations.SerializedName;
+
+import android.support.annotation.NonNull;
 
 import java.lang.reflect.Field;
 

--- a/appshared/src/main/java/io/reark/rxgithubapp/shared/utils/NullNetworkInstrumentation.java
+++ b/appshared/src/main/java/io/reark/rxgithubapp/shared/utils/NullNetworkInstrumentation.java
@@ -26,14 +26,16 @@
 package io.reark.rxgithubapp.shared.utils;
 
 import android.support.annotation.NonNull;
+
 import io.reark.rxgithubapp.shared.network.NetworkInstrumentation;
 import okhttp3.OkHttpClient;
 
-public class NullNetworkInstrumentation implements NetworkInstrumentation<OkHttpClient> {
+public class NullNetworkInstrumentation implements NetworkInstrumentation<OkHttpClient.Builder> {
+
     @NonNull
     @Override
-    public OkHttpClient decorateNetwork(@NonNull OkHttpClient httpClient) {
-        return httpClient.newBuilder().build();
+    public OkHttpClient.Builder decorateNetwork(@NonNull final OkHttpClient.Builder clientBuilder) {
+        return clientBuilder;
     }
 
     @Override

--- a/appshared/src/main/java/io/reark/rxgithubapp/shared/view/RepositoriesAdapter.java
+++ b/appshared/src/main/java/io/reark/rxgithubapp/shared/view/RepositoriesAdapter.java
@@ -25,6 +25,8 @@
  */
 package io.reark.rxgithubapp.shared.view;
 
+import com.bumptech.glide.Glide;
+
 import android.support.annotation.NonNull;
 import android.support.v7.widget.RecyclerView.Adapter;
 import android.support.v7.widget.RecyclerView.ViewHolder;
@@ -33,8 +35,6 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.TextView;
-
-import com.bumptech.glide.Glide;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/appshared/src/main/java/io/reark/rxgithubapp/shared/view/RepositoriesView.java
+++ b/appshared/src/main/java/io/reark/rxgithubapp/shared/view/RepositoriesView.java
@@ -25,6 +25,8 @@
  */
 package io.reark.rxgithubapp.shared.view;
 
+import com.jakewharton.rxbinding.widget.RxTextView;
+
 import android.content.Context;
 import android.support.annotation.NonNull;
 import android.support.v7.widget.LinearLayoutManager;
@@ -34,8 +36,6 @@ import android.view.View;
 import android.widget.EditText;
 import android.widget.FrameLayout;
 import android.widget.TextView;
-
-import com.jakewharton.rxbinding.widget.RxTextView;
 
 import java.util.Collections;
 import java.util.List;

--- a/appshared/src/main/java/io/reark/rxgithubapp/shared/view/RepositoryView.java
+++ b/appshared/src/main/java/io/reark/rxgithubapp/shared/view/RepositoryView.java
@@ -25,15 +25,15 @@
  */
 package io.reark.rxgithubapp.shared.view;
 
+import com.bumptech.glide.Glide;
+import com.bumptech.glide.load.resource.drawable.GlideDrawable;
+
 import android.content.Context;
 import android.support.annotation.NonNull;
 import android.util.AttributeSet;
 import android.widget.FrameLayout;
 import android.widget.ImageView;
 import android.widget.TextView;
-
-import com.bumptech.glide.Glide;
-import com.bumptech.glide.load.resource.drawable.GlideDrawable;
 
 import io.reark.reark.utils.RxViewBinder;
 import io.reark.rxgithubapp.shared.R;

--- a/appshared/src/release/java/io/reark/rxgithubapp/shared/injections/InstrumentationModule.java
+++ b/appshared/src/release/java/io/reark/rxgithubapp/shared/injections/InstrumentationModule.java
@@ -26,8 +26,9 @@
 package io.reark.rxgithubapp.shared.injections;
 
 import android.content.Context;
-import okhttp3.OkHttpClient;
+
 import javax.inject.Singleton;
+
 import dagger.Module;
 import dagger.Provides;
 import io.reark.rxgithubapp.shared.injections.ForApplication;
@@ -35,6 +36,7 @@ import io.reark.rxgithubapp.shared.network.NetworkInstrumentation;
 import io.reark.rxgithubapp.shared.utils.ApplicationInstrumentation;
 import io.reark.rxgithubapp.shared.utils.NullInstrumentation;
 import io.reark.rxgithubapp.shared.utils.NullNetworkInstrumentation;
+import okhttp3.OkHttpClient;
 
 @Module
 public class InstrumentationModule {
@@ -47,7 +49,7 @@ public class InstrumentationModule {
 
     @Provides
     @Singleton
-    public NetworkInstrumentation<OkHttpClient> providesNetworkInstrumentation() {
+    public NetworkInstrumentation<OkHttpClient.Builder> providesNetworkInstrumentation() {
         return new NullNetworkInstrumentation();
     }
 }

--- a/appshared/src/test/java/io/reark/rxgithubapp/shared/utils/NullNetworkInstrumentationTest.java
+++ b/appshared/src/test/java/io/reark/rxgithubapp/shared/utils/NullNetworkInstrumentationTest.java
@@ -25,7 +25,16 @@
  */
 package io.reark.rxgithubapp.shared.utils;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Before;
+import org.junit.Test;
+import org.junit.runners.JUnit4;
+
+import okhttp3.OkHttpClient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyZeroInteractions;
 
 public class NullNetworkInstrumentationTest {
 
@@ -36,5 +45,13 @@ public class NullNetworkInstrumentationTest {
         instrumentation = new NullNetworkInstrumentation();
     }
 
+    @Test
+    public void testDecorateNetwork_DoesNotChangeTheHttpClient() {
+        OkHttpClient.Builder clientBuilder = new OkHttpClient.Builder();
+
+        instrumentation.decorateNetwork(clientBuilder);
+
+        assertThat(clientBuilder.networkInterceptors()).isEmpty();
+    }
 
 }

--- a/appshared/src/test/java/io/reark/rxgithubapp/shared/utils/SubscriptionUtilsTest.java
+++ b/appshared/src/test/java/io/reark/rxgithubapp/shared/utils/SubscriptionUtilsTest.java
@@ -25,15 +25,15 @@
  */
 package io.reark.rxgithubapp.shared.utils;
 
-import android.graphics.Color;
-import android.widget.TextView;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+
+import android.graphics.Color;
+import android.widget.TextView;
 
 import rx.Observable;
 import rx.android.schedulers.AndroidSchedulers;

--- a/appshared/src/testDebug/java/io/reark/rxgithubapp/shared/utils/StethoInstrumentationTest.java
+++ b/appshared/src/testDebug/java/io/reark/rxgithubapp/shared/utils/StethoInstrumentationTest.java
@@ -25,21 +25,22 @@
  */
 package io.reark.rxgithubapp.shared.utils;
 
-import android.content.Context;
-
-import okhttp3.Interceptor;
-import okhttp3.OkHttpClient;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import java.util.List;
-import static org.mockito.Matchers.eq;
+
+import android.content.Context;
+
+import okhttp3.Interceptor;
+import okhttp3.OkHttpClient;
+
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 public class StethoInstrumentationTest {
 
@@ -51,14 +52,26 @@ public class StethoInstrumentationTest {
     @Before
     public void setUp() {
         MockitoAnnotations.initMocks(this);
+
         instrumentation = spy(new StethoInstrumentation(mock(Context.class), interceptor));
     }
 
     @Test
     public void testInitDoesNotThrow() {
         doNothing().when(instrumentation).initStetho();
+
         instrumentation.init();
 
         verify(instrumentation).initStetho();
+    }
+
+    @Test
+    public void testDecorateNetwork() {
+        OkHttpClient.Builder clientBuilder = new OkHttpClient.Builder();
+
+        instrumentation.decorateNetwork(clientBuilder);
+
+        assertThat(clientBuilder.networkInterceptors())
+                .containsExactlyElementsOf(singletonList(interceptor));
     }
 }

--- a/reark/src/androidTest/java/io/reark/reark/data/stores/ContentProviderStoreTest.java
+++ b/reark/src/androidTest/java/io/reark/reark/data/stores/ContentProviderStoreTest.java
@@ -25,6 +25,10 @@
  */
 package io.reark.reark.data.stores;
 
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
 import android.content.ContentResolver;
 import android.content.ContentValues;
 import android.database.Cursor;
@@ -32,10 +36,6 @@ import android.net.Uri;
 import android.support.annotation.NonNull;
 import android.support.test.runner.AndroidJUnit4;
 import android.test.ProviderTestCase2;
-
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 
 import java.util.Arrays;
 import java.util.Collections;

--- a/reark/src/main/java/io/reark/reark/network/fetchers/FetcherBase.java
+++ b/reark/src/main/java/io/reark/reark/network/fetchers/FetcherBase.java
@@ -33,7 +33,6 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import io.reark.reark.pojo.NetworkRequestStatus;
 import io.reark.reark.utils.Log;
-import io.reark.reark.utils.Preconditions;
 import retrofit2.adapter.rxjava.HttpException;
 import rx.Subscription;
 import rx.functions.Action1;

--- a/reark/src/test/java/io/reark/reark/data/stores/MemoryStoreTest.java
+++ b/reark/src/test/java/io/reark/reark/data/stores/MemoryStoreTest.java
@@ -25,10 +25,10 @@
  */
 package io.reark.reark.data.stores;
 
-import android.support.v4.util.Pair;
-
 import org.junit.Before;
 import org.junit.Test;
+
+import android.support.v4.util.Pair;
 
 import java.util.concurrent.TimeUnit;
 

--- a/reark/src/test/java/io/reark/reark/pojo/OverwritablePojoTest.java
+++ b/reark/src/test/java/io/reark/reark/pojo/OverwritablePojoTest.java
@@ -25,9 +25,9 @@
  */
 package io.reark.reark.pojo;
 
-import android.support.annotation.NonNull;
-
 import org.junit.Test;
+
+import android.support.annotation.NonNull;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;

--- a/reark/src/test/java/io/reark/reark/utils/RxViewBinderTest.java
+++ b/reark/src/test/java/io/reark/reark/utils/RxViewBinderTest.java
@@ -25,8 +25,6 @@
  */
 package io.reark.reark.utils;
 
-import android.support.annotation.NonNull;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -34,6 +32,8 @@ import org.mockito.MockitoAnnotations;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+
+import android.support.annotation.NonNull;
 
 import rx.android.schedulers.AndroidSchedulers;
 import rx.observers.TestSubscriber;


### PR DESCRIPTION
The merged Retrofit 2 solution creates new clients every time it's decorated. This changes to use builders instead for decoration to avoid new client creation.