### PR TITLE
Update dependencies and clean gradle files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ android:
     - platform-tools
     - tools
     - android-24
-    - build-tools-25.0.0
+    - build-tools-25.0.2
     - extra-google-m2repository
     - extra-android-m2repository
     - sys-img-armeabi-v7a-android-24
@@ -21,6 +21,11 @@ before_script:
   - adb shell settings put global transition_animation_scale 0 &
   - adb shell settings put global animator_duration_scale 0 &
   - adb shell input keyevent 82 &
+
+licenses:
+  - 'android-sdk-preview-license-.+'
+  - 'android-sdk-license-.+'
+  - 'google-gdk-license-.+'
 
 script:
   - ./gradlew test spoon

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ android:
     - platform-tools
     - tools
     - android-24
+    - android-25
     - build-tools-25.0.2
     - extra-google-m2repository
     - extra-android-m2repository
@@ -21,11 +22,6 @@ before_script:
   - adb shell settings put global transition_animation_scale 0 &
   - adb shell settings put global animator_duration_scale 0 &
   - adb shell input keyevent 82 &
-
-licenses:
-  - 'android-sdk-preview-license-.+'
-  - 'android-sdk-license-.+'
-  - 'google-gdk-license-.+'
 
 script:
   - ./gradlew test spoon

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,25 +3,13 @@ apply plugin: 'me.tatarka.retrolambda'
 apply plugin: 'com.neenbedankt.android-apt'
 apply plugin: 'spoon'
 
-buildscript {
-    repositories {
-        mavenCentral()
-        maven { url 'https://oss.sonatype.org/content/repositories/snapshots/' }
-    }
-}
-
-repositories {
-    maven { url 'https://oss.sonatype.org/content/repositories/snapshots/' }
-    mavenCentral()
-}
-
 android {
-    compileSdkVersion 24
-    buildToolsVersion "25.0.0"
+    compileSdkVersion 25
+    buildToolsVersion "25.0.2"
 
     defaultConfig {
         minSdkVersion 15
-        targetSdkVersion 24
+        targetSdkVersion 25
         versionCode 1
         versionName "1.0"
 
@@ -29,7 +17,6 @@ android {
     }
     dexOptions {
         preDexLibraries false
-        incremental true
     }
     signingConfigs {
         release {
@@ -50,79 +37,24 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
-
     testOptions {
         unitTests.returnDefaultValues = true
     }
-
-    lintOptions {
-        // For Okio
-        // https://github.com/square/okio/issues/58
-        warning 'InvalidPackage'
-    }
-
-    packagingOptions {
-        exclude 'LICENSE.txt'
-    }
-}
-
-retrolambda {
-    jvmArgs '-noverify'
 }
 
 dependencies {
     debugCompile project(path: ':appshared', configuration: 'debug')
     releaseCompile project(path: ':appshared', configuration: 'release')
 
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-
-    compile 'com.github.bumptech.glide:glide:3.7.0'
-    compile 'com.android.support:recyclerview-v7:24.2.1'
-
     // Schematic
-    apt 'net.simonvt.schematic:schematic-compiler:0.6.7'
-    compile 'net.simonvt.schematic:schematic:0.6.7'
+    apt 'net.simonvt.schematic:schematic-compiler:0.7.0'
+    compile 'net.simonvt.schematic:schematic:0.7.0'
 
     // Dagger
-    apt 'com.google.guava:guava:19.0'
-    apt 'com.google.dagger:dagger-compiler:2.3'
+    apt 'com.google.guava:guava:20.0'
+    apt 'com.google.dagger:dagger-compiler:2.8'
 
-    // Unit test build
-    testCompile 'junit:junit:4.12'
-    testCompile 'org.mockito:mockito-core:1.10.19'
-    testCompile 'org.powermock:powermock-api-mockito:1.6.4'
-    testCompile 'org.powermock:powermock-module-junit4:1.6.4'
-
-    androidTestCompile 'com.android.support:support-annotations:24.2.1'
-    androidTestCompile 'com.android.support.test:runner:0.5'
+    // Android test build
     androidTestCompile 'com.android.support.test:rules:0.5'
     androidTestCompile 'com.android.support.test.espresso:espresso-core:2.2.2'
-    androidTestCompile 'com.android.support.test.espresso:espresso-intents:2.2.2'
-    androidTestCompile 'org.mockito:mockito-core:1.10.19'
-    androidTestCompile "com.google.dexmaker:dexmaker:1.2"
-    androidTestCompile "com.google.dexmaker:dexmaker-mockito:1.2"
-}
-
-// Get the path to ADB.  Required when running tests directly from Android Studio.
-// Source: http://stackoverflow.com/a/26771087/112705
-def adb = android.getAdbExe().toString()
-def packageName = 'io.reark.rxgithubapp.advanced'
-def command = "$adb shell pm grant $packageName android.permission.SET_ANIMATION_SCALE".split(' ')
-
-task grantAnimationPermission(type: Exec, dependsOn: 'installDebug') {
-    println ""
-    println '================================================='
-    println 'Granting permission to disable animations'
-    commandLine command
-    println '================================================='
-}
-
-afterEvaluate {
-    // When launching individual tests from Android Studio, it seems that only the assemble tasks
-    // get called directly, not the install* versions
-    tasks.each { task ->
-        if (task.name.startsWith('assembleDebugAndroidTest')) {
-            task.dependsOn grantAnimationPermission
-        }
-    }
 }

--- a/appbasic/build.gradle
+++ b/appbasic/build.gradle
@@ -2,33 +2,18 @@ apply plugin: 'com.android.application'
 apply plugin: 'me.tatarka.retrolambda'
 apply plugin: 'com.neenbedankt.android-apt'
 
-buildscript {
-    repositories {
-        mavenCentral()
-        maven { url 'https://oss.sonatype.org/content/repositories/snapshots/' }
-    }
-}
-
-repositories {
-    maven { url 'https://oss.sonatype.org/content/repositories/snapshots/' }
-    mavenCentral()
-}
-
 android {
-    compileSdkVersion 24
-    buildToolsVersion "25.0.0"
+    compileSdkVersion 25
+    buildToolsVersion "25.0.2"
 
     defaultConfig {
         minSdkVersion 15
-        targetSdkVersion 24
+        targetSdkVersion 25
         versionCode 1
         versionName "1.0"
-
-        testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'
     }
     dexOptions {
         preDexLibraries false
-        incremental true
     }
     signingConfigs {
         release {
@@ -49,75 +34,13 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
-
-    testOptions {
-        unitTests.returnDefaultValues = true
-    }
-
-    lintOptions {
-        // For Okio
-        // https://github.com/square/okio/issues/58
-        warning 'InvalidPackage'
-    }
-
-    packagingOptions {
-        exclude 'LICENSE.txt'
-    }
-}
-
-retrolambda {
-    jvmArgs '-noverify'
 }
 
 dependencies {
     debugCompile project(path: ':appshared', configuration: 'debug')
     releaseCompile project(path: ':appshared', configuration: 'release')
 
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-
-    compile 'com.github.bumptech.glide:glide:3.7.0'
-    compile 'com.android.support:recyclerview-v7:24.2.1'
-
     // Dagger
-    apt 'com.google.guava:guava:19.0'
-    apt 'com.google.dagger:dagger-compiler:2.3'
-
-    // Unit test build
-    testCompile 'junit:junit:4.12'
-    testCompile 'org.mockito:mockito-core:1.10.19'
-    testCompile 'org.powermock:powermock-api-mockito:1.6.4'
-    testCompile 'org.powermock:powermock-module-junit4:1.6.4'
-
-    androidTestCompile 'com.android.support:support-annotations:24.2.1'
-    androidTestCompile 'com.android.support.test:runner:0.5'
-    androidTestCompile 'com.android.support.test:rules:0.5'
-    androidTestCompile 'com.android.support.test.espresso:espresso-core:2.2.2'
-    androidTestCompile 'com.android.support.test.espresso:espresso-intents:2.2.2'
-    androidTestCompile 'org.mockito:mockito-core:1.10.19'
-    androidTestCompile "com.google.dexmaker:dexmaker:1.2"
-    androidTestCompile "com.google.dexmaker:dexmaker-mockito:1.2"
-}
-
-// Get the path to ADB.  Required when running tests directly from Android Studio.
-// Source: http://stackoverflow.com/a/26771087/112705
-def adb = android.getAdbExe().toString()
-def packageName = 'io.reark.rxgithubapp.basic'
-def command = "$adb shell pm grant $packageName android.permission.SET_ANIMATION_SCALE".split(' ')
-
-task grantAnimationPermission(type: Exec, dependsOn: 'installDebug') {
-    println ""
-    println '================================================='
-    println 'Granting permission to disable animations'
-    commandLine command
-    println '================================================='
-}
-
-afterEvaluate {
-    // When launching individual tests from Android Studio, it seems that only the assemble tasks
-    // get called directly, not the install* versions
-    tasks.each { task ->
-        if (task.name.startsWith('assembleDebugAndroidTest')) {
-            task.dependsOn grantAnimationPermission
-        }
-    }
+    apt 'com.google.guava:guava:20.0'
+    apt 'com.google.dagger:dagger-compiler:2.8'
 }

--- a/appshared/build.gradle
+++ b/appshared/build.gradle
@@ -3,13 +3,13 @@ apply plugin: 'me.tatarka.retrolambda'
 apply plugin: 'com.neenbedankt.android-apt'
 
 android {
-    compileSdkVersion 24
-    buildToolsVersion "25.0.0"
+    compileSdkVersion 25
+    buildToolsVersion "25.0.2"
     publishNonDefault true
 
     defaultConfig {
         minSdkVersion 15
-        targetSdkVersion 24
+        targetSdkVersion 25
         versionCode 1
         versionName "1.0"
     }
@@ -32,48 +32,34 @@ dependencies {
     debugCompile project(path: ':reark', configuration: 'debug')
     releaseCompile project(path: ':reark', configuration: 'release')
 
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    testCompile 'junit:junit:4.12'
+    // Support libraries
+    compile 'com.android.support:recyclerview-v7:25.1.0'
 
-    compile 'javax.annotation:jsr250-api:1.0'
-    compile 'com.squareup.okhttp3:okhttp-android-support:3.2.0'
-    compile 'com.squareup.retrofit2:retrofit:2.0.0'
-    compile 'com.squareup.retrofit2:adapter-rxjava:2.0.0'
-    compile 'com.squareup.retrofit2:converter-gson:2.0.0'
-    compile 'com.android.support:appcompat-v7:24.2.1'
+    // Retrofit
+    compile 'com.squareup.okhttp3:okhttp-android-support:3.5.0'
+    compile 'com.squareup.retrofit2:retrofit:2.1.0'
+    compile 'com.squareup.retrofit2:adapter-rxjava:2.1.0'
+    compile 'com.squareup.retrofit2:converter-gson:2.1.0'
 
-    // RxJava
-    compile 'io.reactivex:rxjava:1.2.3'
-    compile 'io.reactivex:rxandroid:1.2.1'
+    // Glide
+    compile 'com.github.bumptech.glide:glide:3.7.0'
 
     // Dagger
-    apt 'com.google.guava:guava:19.0'
-    compile 'com.google.dagger:dagger:2.3'
-    apt 'com.google.dagger:dagger-compiler:2.3'
+    apt 'com.google.guava:guava:20.0'
+    compile 'com.google.dagger:dagger:2.8'
+    apt 'com.google.dagger:dagger-compiler:2.8'
 
     // Stetho
-    debugCompile 'com.facebook.stetho:stetho:1.4.1'
-    debugCompile 'com.facebook.stetho:stetho-okhttp3:1.4.1'
+    debugCompile 'com.facebook.stetho:stetho:1.4.2'
+    debugCompile 'com.facebook.stetho:stetho-okhttp3:1.4.2'
 
     // Leak tracing
-    debugCompile 'com.squareup.leakcanary:leakcanary-android:1.3.1'
-    releaseCompile 'com.squareup.leakcanary:leakcanary-android-no-op:1.3.1'
+    debugCompile 'com.squareup.leakcanary:leakcanary-android:1.5'
+    releaseCompile 'com.squareup.leakcanary:leakcanary-android-no-op:1.5'
 
     // Unit test build
     testCompile 'junit:junit:4.12'
-    testCompile 'org.assertj:assertj-core:1.7.1'
-    testCompile 'org.mockito:mockito-core:1.10.19'
-    testCompile 'org.powermock:powermock-api-mockito:1.6.4'
-    testCompile 'org.powermock:powermock-module-junit4:1.6.4'
-
-    androidTestCompile 'com.android.support:support-annotations:24.2.1'
-    androidTestCompile 'com.android.support.test:runner:0.5'
-    androidTestCompile 'com.android.support.test:rules:0.5'
-    androidTestCompile 'com.android.support.test.espresso:espresso-core:2.2.2'
-    androidTestCompile 'com.android.support.test.espresso:espresso-intents:2.2.2'
-    androidTestCompile 'org.mockito:mockito-core:1.10.19'
-    androidTestCompile "com.google.dexmaker:dexmaker:1.2"
-    androidTestCompile "com.google.dexmaker:dexmaker-mockito:1.2"
-    compile 'com.github.bumptech.glide:glide:3.7.0'
-    compile 'com.android.support:recyclerview-v7:24.2.1'
+    testCompile 'org.assertj:assertj-core:3.6.1'
+    testCompile 'org.powermock:powermock-api-mockito:1.6.6'
+    testCompile 'org.powermock:powermock-module-junit4:1.6.6'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -6,11 +6,17 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.2'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'
-        classpath 'me.tatarka:gradle-retrolambda:3.2.5'
-        classpath 'com.github.ben-manes:gradle-versions-plugin:0.12.0'
+        classpath 'me.tatarka:gradle-retrolambda:3.4.0'
+        classpath 'com.github.ben-manes:gradle-versions-plugin:0.13.0'
         classpath 'com.stanfy.spoon:spoon-gradle-plugin:1.2.2'
+    }
+}
+
+allprojects {
+    repositories {
+        mavenCentral()
     }
 }
 
@@ -24,11 +30,5 @@ dependencyUpdates.resolutionStrategy = {
                 selection.reject('Release candidate')
             }
         }
-    }
-}
-
-allprojects {
-    repositories {
-        mavenCentral()
     }
 }

--- a/reark/build.gradle
+++ b/reark/build.gradle
@@ -4,20 +4,14 @@ apply plugin: 'maven'
 apply plugin: 'signing'
 apply plugin: 'spoon'
 
-buildscript {
-    repositories {
-        mavenCentral()
-    }
-}
-
 android {
-    compileSdkVersion 24
-    buildToolsVersion "25.0.0"
+    compileSdkVersion 25
+    buildToolsVersion "25.0.2"
     publishNonDefault true
 
     defaultConfig {
         minSdkVersion 15
-        targetSdkVersion 24
+        targetSdkVersion 25
         versionCode 1
         versionName "1.0"
 
@@ -43,32 +37,34 @@ configurations {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:24.2.1'
-    compile 'com.android.support:support-annotations:24.2.1'
-    compile 'com.squareup.retrofit2:retrofit:2.0.0'
-    compile 'com.squareup.retrofit2:adapter-rxjava:2.0.0'
-    compile 'com.squareup.retrofit2:converter-gson:2.0.0'
+    // Support libraries
+    compile 'com.android.support:appcompat-v7:25.1.0'
+    compile 'com.android.support:support-annotations:25.1.0'
+
+    // Retrofit
+    compile 'com.squareup.retrofit2:retrofit:2.1.0'
+    compile 'com.squareup.retrofit2:adapter-rxjava:2.1.0'
+    compile 'com.squareup.retrofit2:converter-gson:2.1.0'
 
     // RxJava
-    compile 'io.reactivex:rxjava:1.2.3'
+    compile 'io.reactivex:rxjava:1.2.5'
     compile 'io.reactivex:rxandroid:1.2.1'
 
     // RxBinding wrappers
-    compile 'com.jakewharton.rxbinding:rxbinding:0.3.0'
+    compile 'com.jakewharton.rxbinding:rxbinding:1.0.0'
 
     // Unit test build
     testCompile 'junit:junit:4.12'
-    testCompile 'org.mockito:mockito-core:1.10.19'
-    testCompile 'org.powermock:powermock-api-mockito:1.6.4'
-    testCompile 'org.powermock:powermock-module-junit4:1.6.4'
+    testCompile 'org.powermock:powermock-api-mockito:1.6.6'
+    testCompile 'org.powermock:powermock-module-junit4:1.6.6'
 
-    androidTestCompile 'com.android.support:support-annotations:24.2.1'
+    // Android test build
+    androidTestCompile 'com.android.support:support-annotations:25.1.0'
     androidTestCompile 'com.android.support.test:runner:0.5'
 
     // Javadoc generation needs dependencies in classpath
-    javadocDeps 'com.android.support:support-annotations:24.2.1'
-    javadocDeps 'io.reactivex:rxjava:1.2.3'
+    javadocDeps 'com.android.support:support-annotations:25.1.0'
+    javadocDeps 'io.reactivex:rxjava:1.2.5'
     javadocDeps 'io.reactivex:rxandroid:1.2.1'
 }
 


### PR DESCRIPTION
Split to multiple modules brought needless duplication to gradle files. This simplifies the situation, and updates the dependencies while at it.