### PR TITLE
Filter only after debounce

### DIFF
--- a/appshared/src/main/java/io/reark/rxgithubapp/shared/viewmodels/RepositoriesViewModel.java
+++ b/appshared/src/main/java/io/reark/rxgithubapp/shared/viewmodels/RepositoriesViewModel.java
@@ -129,9 +129,9 @@ public class RepositoriesViewModel extends AbstractViewModel {
 
         ConnectableObservable<DataStreamNotification<GitHubRepositorySearch>> repositorySearchSource =
                 searchString
-                        .filter(value -> value.length() > 2)
                         .debounce(SEARCH_INPUT_DELAY, TimeUnit.MILLISECONDS)
                         .distinctUntilChanged()
+                        .filter(value -> value.length() > 2)
                         .doOnNext(value -> Log.d(TAG, "Searching with: " + value))
                         .switchMap(getGitHubRepositorySearch::call)
                         .publish();


### PR DESCRIPTION
Small fix: filter only after debounce, otherwise a partial search will be executed when user is clearing the search text box with backspace key. It's annoying when testing.