### PR TITLE
Add getStream for ContentProviderStoreCore

### DIFF
--- a/app/src/androidTest/java/io/reark/rxgithubapp/advanced/data/stores/GitHubRepositoryStoreTest.java
+++ b/app/src/androidTest/java/io/reark/rxgithubapp/advanced/data/stores/GitHubRepositoryStoreTest.java
@@ -1,18 +1,18 @@
 package io.reark.rxgithubapp.advanced.data.stores;
 
-import com.google.gson.Gson;
-
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-
 import android.content.pm.ProviderInfo;
 import android.support.annotation.NonNull;
 import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
 import android.test.ProviderTestCase2;
 import android.test.mock.MockContentResolver;
+
+import com.google.gson.Gson;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import java.util.concurrent.TimeUnit;
 

--- a/app/src/androidTest/java/io/reark/rxgithubapp/advanced/data/stores/cores/GitHubRepositoryStoreCoreTest.java
+++ b/app/src/androidTest/java/io/reark/rxgithubapp/advanced/data/stores/cores/GitHubRepositoryStoreCoreTest.java
@@ -151,7 +151,7 @@ public class GitHubRepositoryStoreCoreTest extends ProviderTestCase2<GitHubProvi
         gitHubRepositoryStoreCore.put(300, value3);
 
         // ASSERT
-        testSubscriber.awaitTerminalEvent(500, TimeUnit.MILLISECONDS);
+        testSubscriber.awaitTerminalEvent(1500, TimeUnit.MILLISECONDS);
         testSubscriber.assertCompleted();
         testSubscriber.assertNoErrors();
         testSubscriber.assertValue(asList(value1, value2));

--- a/app/src/main/java/io/reark/rxgithubapp/advanced/data/stores/cores/GitHubRepositoryStoreCore.java
+++ b/app/src/main/java/io/reark/rxgithubapp/advanced/data/stores/cores/GitHubRepositoryStoreCore.java
@@ -33,12 +33,16 @@ import android.database.Cursor;
 import android.net.Uri;
 import android.support.annotation.NonNull;
 
+import java.util.List;
+
+import io.reark.reark.data.stores.StoreItem;
 import io.reark.reark.data.stores.cores.ContentProviderStoreCore;
 import io.reark.reark.utils.Preconditions;
 import io.reark.rxgithubapp.advanced.data.schematicProvider.GitHubProvider;
 import io.reark.rxgithubapp.advanced.data.schematicProvider.GitHubProvider.GitHubRepositories;
 import io.reark.rxgithubapp.advanced.data.schematicProvider.JsonIdColumns;
 import io.reark.rxgithubapp.shared.pojo.GitHubRepository;
+import rx.Observable;
 
 import static io.reark.reark.utils.Preconditions.checkNotNull;
 
@@ -50,6 +54,16 @@ public class GitHubRepositoryStoreCore extends ContentProviderStoreCore<Integer,
         super(contentResolver);
 
         this.gson = Preconditions.get(gson);
+    }
+
+    @NonNull
+    public Observable<List<GitHubRepository>> getAllCached() {
+        return getAllOnce(getContentUri());
+    }
+
+    @NonNull
+    public Observable<GitHubRepository> getAllStream() {
+        return getStream().map(StoreItem::item);
     }
 
     @NonNull

--- a/reark/src/main/java/io/reark/reark/data/stores/ContentProviderStore.java
+++ b/reark/src/main/java/io/reark/reark/data/stores/ContentProviderStore.java
@@ -27,13 +27,8 @@ package io.reark.reark.data.stores;
 
 import android.support.annotation.NonNull;
 
-import java.util.List;
-
 import io.reark.reark.data.stores.cores.ContentProviderStoreCore;
 import io.reark.reark.utils.Preconditions;
-import rx.Observable;
-
-import static io.reark.reark.utils.Preconditions.checkNotNull;
 
 /**
  * ContentProviderStore is a convenience implementation of ContentProviderStoreCoreBase for
@@ -45,6 +40,7 @@ import static io.reark.reark.utils.Preconditions.checkNotNull;
  *
  * @param <T> Type of the id used in this store.
  * @param <U> Type of the data this store contains.
+ * @param <R> Non-null type or wrapper for the data this store contains.
  */
 public class ContentProviderStore<T, U, R> extends DefaultStore<T, U, R> {
 
@@ -58,16 +54,5 @@ public class ContentProviderStore<T, U, R> extends DefaultStore<T, U, R> {
         super(core, getIdForItem, getNullSafe, getEmptyValue);
 
         this.core = Preconditions.get(core);
-    }
-
-    /**
-     * Returns a completing Observable of all items matching the id. This method can be used to
-     * request all the contents of this store by providing an empty id.
-     */
-    @NonNull
-    public Observable<List<U>> getAllOnce(@NonNull final T id) {
-        checkNotNull(id);
-
-        return core.getAllCached(id);
     }
 }

--- a/reark/src/main/java/io/reark/reark/data/stores/cores/ContentProviderStoreCore.java
+++ b/reark/src/main/java/io/reark/reark/data/stores/cores/ContentProviderStoreCore.java
@@ -30,8 +30,6 @@ import android.database.ContentObserver;
 import android.net.Uri;
 import android.support.annotation.NonNull;
 
-import java.util.List;
-
 import io.reark.reark.data.stores.StoreItem;
 import io.reark.reark.data.stores.interfaces.StoreCoreInterface;
 import io.reark.reark.utils.Log;
@@ -88,24 +86,22 @@ public abstract class ContentProviderStoreCore<T, U>
         };
     }
 
+    /**
+     * Get a full stream of items with no identifier filtering. Whenever a store receives a new
+     * item with the id, it pushes it to the stream.
+     *
+     * @return An observable that first emits all future items as they are inserted into the store.
+     */
+    @NonNull
+    protected Observable<StoreItem<T, U>> getStream() {
+        return subjectCache.asObservable();
+    }
+
     @Override
     public void put(@NonNull final T id, @NonNull final U item) {
         checkNotNull(id);
 
         put(Preconditions.get(item), getUriForId(id));
-    }
-
-    /**
-     * Returns an observable that emits all stored values for the given id and completes.
-     *
-     * @param id Store item id.
-     * @return Values associated with the given id.
-     */
-    @NonNull
-    public Observable<List<U>> getAllCached(@NonNull final T id) {
-        checkNotNull(id);
-
-        return getAllOnce(getUriForId(id));
     }
 
     @NonNull

--- a/reark/src/main/java/io/reark/reark/data/stores/cores/MemoryStoreCore.java
+++ b/reark/src/main/java/io/reark/reark/data/stores/cores/MemoryStoreCore.java
@@ -60,7 +60,7 @@ public class MemoryStoreCore<T, U> implements StoreCoreInterface<T, U> {
     private final Map<Integer, U> cache = new ConcurrentHashMap<>(10);
 
     @NonNull
-    private final Subject<StoreItem<T, U>, StoreItem<T, U>> subject = PublishSubject.create();
+    private final PublishSubject<StoreItem<T, U>> subject = PublishSubject.create();
 
     @NonNull
     private final ConcurrentMap<Integer, Subject<U, U>> subjectCache = new ConcurrentHashMap<>(20, 0.75f, 4);
@@ -73,6 +73,12 @@ public class MemoryStoreCore<T, U> implements StoreCoreInterface<T, U> {
         this.putMergeFunction = get(putMergeFunction);
     }
 
+    /**
+     * Get a full stream of items with no identifier filtering. Whenever a store receives a new
+     * item with the id, it pushes it to the stream.
+     *
+     * @return An observable that first emits all future items as they are inserted into the store.
+     */
     @NonNull
     protected Observable<StoreItem<T, U>> getStream() {
         return subject.asObservable();


### PR DESCRIPTION
MemoryStoreCore already contains protected `getStream()` that doesn't filter. It's useful method for extending classes that wish to access all incoming items, so add a similar one for the content provider version.