### PR TITLE
add method getStream for StoreGetInterface

### DIFF
--- a/appshared/src/main/java/io/reark/rxgithubapp/shared/data/ClientDataLayerBase.java
+++ b/appshared/src/main/java/io/reark/rxgithubapp/shared/data/ClientDataLayerBase.java
@@ -66,7 +66,7 @@ public abstract class ClientDataLayerBase extends DataLayerBase {
 
         final Observable<NetworkRequestStatus> networkRequestStatusObservable =
                 networkRequestStatusStore
-                        .getOnceAndStream(GitHubRepositorySearchFetcher.getUniqueId(searchString).hashCode())
+                        .getStream(GitHubRepositorySearchFetcher.getUniqueId(searchString).hashCode())
                         .filter(NetworkRequestStatus::isSome);
 
         final Observable<GitHubRepositorySearch> gitHubRepositorySearchObservable =

--- a/reark/src/main/java/io/reark/reark/data/stores/DefaultStore.java
+++ b/reark/src/main/java/io/reark/reark/data/stores/DefaultStore.java
@@ -78,6 +78,12 @@ public class DefaultStore<T, U, R> implements StoreInterface<T, U, R> {
 
     @NonNull
     @Override
+    public Observable<R> getStream(@NonNull T id) {
+        return core.getStream(id).map(getNullSafe::call);
+    }
+
+    @NonNull
+    @Override
     public Observable<R> getOnce(@NonNull final T id) {
         checkNotNull(id);
 

--- a/reark/src/main/java/io/reark/reark/data/stores/interfaces/StoreGetInterface.java
+++ b/reark/src/main/java/io/reark/reark/data/stores/interfaces/StoreGetInterface.java
@@ -42,6 +42,17 @@ import rx.Observable;
  * @param <R> Non-null type or wrapper for the data this store contains.
  */
 public interface StoreGetInterface<T, R> {
+
+    /**
+     * Whenever a store receives a new
+     * item with the id, it pushes it to the stream.
+     *
+     * @param id The identifier of the requested object, as defined by the store.
+     * @return An observable that either returns the item with the requested id.
+     */
+    @NonNull
+    Observable<R> getStream(@NonNull final T id);
+
     /**
      * Get the latest item in the store with a specific identifier. The returned observable always
      * completes, unlike in its sibling getOnceAndStream.


### PR DESCRIPTION
If you created method "login", use "final Observable<NetworkRequestStatus> networkRequestStatusObservable =
                networkRequestStatusStore
                        .getOnceAndStream(GitHubRepositorySearchFetcher.getUniqueId(searchString).hashCode())
                        .filter(NetworkRequestStatus::isSome);"

Method "getOnceAndStream" return 200 with latest request.
It is wrong.
I think that " networkRequestStatusStore.getOnceAndStream" must replace for "networkRequestStatusStore.getStream"
