### PR TITLE
Data notifications should not start with stale status

### DIFF
--- a/app/src/main/java/io/reark/rxgithubapp/advanced/data/DataLayer.java
+++ b/app/src/main/java/io/reark/rxgithubapp/advanced/data/DataLayer.java
@@ -44,8 +44,6 @@ public class DataLayer extends ClientDataLayerBase {
 
     private final Context context;
 
-    private int nextListenerIndex = 0;
-
     public DataLayer(@NonNull final Context context,
                      @NonNull final UserSettingsStore userSettingsStore,
                      @NonNull final NetworkRequestStatusStore networkRequestStatusStore,
@@ -66,7 +64,7 @@ public class DataLayer extends ClientDataLayerBase {
     protected int fetchGitHubRepository(@NonNull final Integer repositoryId) {
         checkNotNull(repositoryId);
 
-        int listenerId = ++nextListenerIndex;
+        int listenerId = createListenerId();
 
         Intent intent = new Intent(context, NetworkService.class);
         intent.putExtra("serviceUriString", GitHubService.REPOSITORY.toString());
@@ -81,7 +79,7 @@ public class DataLayer extends ClientDataLayerBase {
     protected int fetchGitHubRepositorySearch(@NonNull final String searchString) {
         checkNotNull(searchString);
 
-        int listenerId = ++nextListenerIndex;
+        int listenerId = createListenerId();
 
         Intent intent = new Intent(context, NetworkService.class);
         intent.putExtra("serviceUriString", GitHubService.REPOSITORY_SEARCH.toString());

--- a/app/src/main/java/io/reark/rxgithubapp/advanced/data/DataLayer.java
+++ b/app/src/main/java/io/reark/rxgithubapp/advanced/data/DataLayer.java
@@ -38,12 +38,13 @@ import io.reark.rxgithubapp.shared.data.ClientDataLayerBase;
 import io.reark.rxgithubapp.shared.network.GitHubService;
 
 import static io.reark.reark.utils.Preconditions.checkNotNull;
-import static io.reark.reark.utils.Preconditions.get;
 
 public class DataLayer extends ClientDataLayerBase {
     private static final String TAG = DataLayer.class.getSimpleName();
 
     private final Context context;
+
+    private int nextListenerIndex = 0;
 
     public DataLayer(@NonNull final Context context,
                      @NonNull final UserSettingsStore userSettingsStore,
@@ -62,18 +63,32 @@ public class DataLayer extends ClientDataLayerBase {
     }
 
     @Override
-    protected void fetchGitHubRepository(@NonNull final Integer repositoryId) {
+    protected int fetchGitHubRepository(@NonNull final Integer repositoryId) {
+        checkNotNull(repositoryId);
+
+        int listenerId = ++nextListenerIndex;
+
         Intent intent = new Intent(context, NetworkService.class);
         intent.putExtra("serviceUriString", GitHubService.REPOSITORY.toString());
-        intent.putExtra("id", get(repositoryId));
+        intent.putExtra("repositoryId", repositoryId);
+        intent.putExtra("listenerId", listenerId);
         context.startService(intent);
+
+        return listenerId;
     }
 
     @Override
-    protected void fetchGitHubRepositorySearch(@NonNull final String searchString) {
+    protected int fetchGitHubRepositorySearch(@NonNull final String searchString) {
+        checkNotNull(searchString);
+
+        int listenerId = ++nextListenerIndex;
+
         Intent intent = new Intent(context, NetworkService.class);
         intent.putExtra("serviceUriString", GitHubService.REPOSITORY_SEARCH.toString());
-        intent.putExtra("searchString", get(searchString));
+        intent.putExtra("searchString", searchString);
+        intent.putExtra("listenerId", listenerId);
         context.startService(intent);
+
+        return listenerId;
     }
 }

--- a/app/src/main/java/io/reark/rxgithubapp/advanced/network/ServiceDataLayer.java
+++ b/app/src/main/java/io/reark/rxgithubapp/advanced/network/ServiceDataLayer.java
@@ -46,31 +46,37 @@ public class ServiceDataLayer extends DataLayerBase {
     @NonNull
     private final UriFetcherManager fetcherManager;
 
-    public ServiceDataLayer(@NonNull final UriFetcherManager fetcherManager,
-                            @NonNull final NetworkRequestStatusStore networkRequestStatusStore,
-                            @NonNull final GitHubRepositoryStore gitHubRepositoryStore,
-                            @NonNull final GitHubRepositorySearchStore gitHubRepositorySearchStore) {
+    public ServiceDataLayer(@NonNull UriFetcherManager fetcherManager,
+                            @NonNull NetworkRequestStatusStore networkRequestStatusStore,
+                            @NonNull GitHubRepositoryStore gitHubRepositoryStore,
+                            @NonNull GitHubRepositorySearchStore gitHubRepositorySearchStore) {
         super(networkRequestStatusStore, gitHubRepositoryStore, gitHubRepositorySearchStore);
 
         this.fetcherManager = get(fetcherManager);
     }
 
-    public void processIntent(@NonNull final Intent intent) {
+    public void processIntent(@NonNull Intent intent) {
         checkNotNull(intent);
 
-        final String serviceUriString = intent.getStringExtra("serviceUriString");
-
-        if (serviceUriString == null) {
-            Log.e(TAG, "No Uri defined");
+        if (!intent.hasExtra("serviceUriString")) {
+            Log.e(TAG, "No service uri defined");
             return;
         }
 
-        final Uri serviceUri = Uri.parse(serviceUriString);
-        final Fetcher<Uri> matchingFetcher = fetcherManager.findFetcher(serviceUri);
+        if (!intent.hasExtra("listenerId")) {
+            Log.e(TAG, "No listener id defined");
+            return;
+        }
+
+        String serviceUriString = intent.getStringExtra("serviceUriString");
+        int listenerId = intent.getIntExtra("listenerId", 0);
+
+        Uri serviceUri = Uri.parse(serviceUriString);
+        Fetcher<Uri> matchingFetcher = fetcherManager.findFetcher(serviceUri);
 
         if (matchingFetcher != null) {
             Log.v(TAG, "Fetcher found for " + serviceUri);
-            matchingFetcher.fetch(intent);
+            matchingFetcher.fetch(intent, listenerId);
         } else {
             Log.e(TAG, "Unknown Uri " + serviceUri);
         }

--- a/app/src/main/java/io/reark/rxgithubapp/advanced/widget/WidgetService.java
+++ b/app/src/main/java/io/reark/rxgithubapp/advanced/widget/WidgetService.java
@@ -25,17 +25,18 @@
  */
 package io.reark.rxgithubapp.advanced.widget;
 
-import com.bumptech.glide.Glide;
-import com.bumptech.glide.request.target.AppWidgetTarget;
-
 import android.app.Service;
 import android.appwidget.AppWidgetManager;
 import android.content.Intent;
 import android.os.IBinder;
 import android.widget.RemoteViews;
 
+import com.bumptech.glide.Glide;
+import com.bumptech.glide.request.target.AppWidgetTarget;
+
 import javax.inject.Inject;
 
+import io.reark.reark.data.DataStreamNotification;
 import io.reark.reark.utils.Log;
 import io.reark.rxgithubapp.R;
 import io.reark.rxgithubapp.advanced.RxGitHubApp;
@@ -90,6 +91,8 @@ public class WidgetService extends Service {
                         .map(UserSettings::getSelectedRepositoryId)
                         .doOnNext(repositoryId -> Log.d(TAG, "Changed repository to " + repositoryId))
                         .switchMap(fetchAndGetGitHubRepository::call)
+                        .filter(DataStreamNotification::isOnNext)
+                        .map(DataStreamNotification::getValue)
                         .subscribeOn(Schedulers.io())
                         .observeOn(AndroidSchedulers.mainThread())
                         .subscribe(repository -> {

--- a/appbasic/src/main/java/io/reark/rxgithubapp/basic/data/DataLayer.java
+++ b/appbasic/src/main/java/io/reark/rxgithubapp/basic/data/DataLayer.java
@@ -62,19 +62,18 @@ public class DataLayer extends ClientDataLayerBase {
 
     @Override
     protected int fetchGitHubRepository(@NonNull final Integer repositoryId) {
-        checkNotNull(repositoryId);
+        Log.d(TAG, "fetchGitHubRepository(" + get(repositoryId) + ")");
 
         int listenerId = createListenerId();
 
         Intent intent = new Intent();
         intent.putExtra("serviceUriString", GitHubService.REPOSITORY.toString());
         intent.putExtra("repositoryId", repositoryId);
-        intent.putExtra("listenerId", listenerId);
 
         Fetcher<Uri> fetcher = fetcherManager.findFetcher(GitHubService.REPOSITORY);
 
         if (fetcher != null) {
-            fetcher.fetch(intent);
+            fetcher.fetch(intent, listenerId);
         }
 
         return listenerId;
@@ -82,20 +81,18 @@ public class DataLayer extends ClientDataLayerBase {
 
     @Override
     protected int fetchGitHubRepositorySearch(@NonNull final String searchString) {
-        checkNotNull(searchString);
+        Log.d(TAG, "fetchGitHubRepositorySearch(" + get(searchString) + ")");
 
         int listenerId = createListenerId();
 
-        Log.d(TAG, "fetchGitHubRepositorySearch(" + searchString + ")");
         Intent intent = new Intent();
         intent.putExtra("serviceUriString", GitHubService.REPOSITORY_SEARCH.toString());
         intent.putExtra("searchString", searchString);
-        intent.putExtra("listenerId", listenerId);
 
         Fetcher<Uri> fetcher = fetcherManager.findFetcher(GitHubService.REPOSITORY_SEARCH);
 
         if (fetcher != null) {
-            fetcher.fetch(intent);
+            fetcher.fetch(intent, listenerId);
         }
 
         return listenerId;

--- a/appbasic/src/main/java/io/reark/rxgithubapp/basic/data/DataLayer.java
+++ b/appbasic/src/main/java/io/reark/rxgithubapp/basic/data/DataLayer.java
@@ -47,8 +47,6 @@ public class DataLayer extends ClientDataLayerBase {
 
     private final UriFetcherManager fetcherManager;
 
-    private int nextListenerId = 0;
-
     public DataLayer(@NonNull final UriFetcherManager fetcherManager,
                      @NonNull final NetworkRequestStatusStore networkRequestStatusStore,
                      @NonNull final GitHubRepositoryStore gitHubRepositoryStore,
@@ -66,7 +64,7 @@ public class DataLayer extends ClientDataLayerBase {
     protected int fetchGitHubRepository(@NonNull final Integer repositoryId) {
         checkNotNull(repositoryId);
 
-        int listenerId = ++nextListenerId;
+        int listenerId = createListenerId();
 
         Intent intent = new Intent();
         intent.putExtra("serviceUriString", GitHubService.REPOSITORY.toString());
@@ -86,7 +84,7 @@ public class DataLayer extends ClientDataLayerBase {
     protected int fetchGitHubRepositorySearch(@NonNull final String searchString) {
         checkNotNull(searchString);
 
-        int listenerId = ++nextListenerId;
+        int listenerId = createListenerId();
 
         Log.d(TAG, "fetchGitHubRepositorySearch(" + searchString + ")");
         Intent intent = new Intent();

--- a/appbasic/src/main/java/io/reark/rxgithubapp/basic/data/DataLayer.java
+++ b/appbasic/src/main/java/io/reark/rxgithubapp/basic/data/DataLayer.java
@@ -47,6 +47,8 @@ public class DataLayer extends ClientDataLayerBase {
 
     private final UriFetcherManager fetcherManager;
 
+    private int nextRequestIndex = 0;
+
     public DataLayer(@NonNull final UriFetcherManager fetcherManager,
                      @NonNull final NetworkRequestStatusStore networkRequestStatusStore,
                      @NonNull final GitHubRepositoryStore gitHubRepositoryStore,
@@ -61,33 +63,43 @@ public class DataLayer extends ClientDataLayerBase {
     }
 
     @Override
-    protected void fetchGitHubRepository(@NonNull final Integer repositoryId) {
+    protected int fetchGitHubRepository(@NonNull final Integer repositoryId) {
         checkNotNull(repositoryId);
+
+        int requestId = ++nextRequestIndex;
 
         Intent intent = new Intent();
         intent.putExtra("serviceUriString", GitHubService.REPOSITORY.toString());
-        intent.putExtra("id", repositoryId);
+        intent.putExtra("repositoryId", repositoryId);
+        intent.putExtra("requestId", requestId);
 
         Fetcher<Uri> fetcher = fetcherManager.findFetcher(GitHubService.REPOSITORY);
 
         if (fetcher != null) {
             fetcher.fetch(intent);
         }
+
+        return requestId;
     }
 
     @Override
-    protected void fetchGitHubRepositorySearch(@NonNull final String searchString) {
+    protected int fetchGitHubRepositorySearch(@NonNull final String searchString) {
         checkNotNull(searchString);
+
+        int requestId = ++nextRequestIndex;
 
         Log.d(TAG, "fetchGitHubRepositorySearch(" + searchString + ")");
         Intent intent = new Intent();
         intent.putExtra("serviceUriString", GitHubService.REPOSITORY_SEARCH.toString());
         intent.putExtra("searchString", searchString);
+        intent.putExtra("requestId", requestId);
 
         Fetcher<Uri> fetcher = fetcherManager.findFetcher(GitHubService.REPOSITORY_SEARCH);
 
         if (fetcher != null) {
             fetcher.fetch(intent);
         }
+
+        return requestId;
     }
 }

--- a/appbasic/src/main/java/io/reark/rxgithubapp/basic/data/DataLayer.java
+++ b/appbasic/src/main/java/io/reark/rxgithubapp/basic/data/DataLayer.java
@@ -47,7 +47,7 @@ public class DataLayer extends ClientDataLayerBase {
 
     private final UriFetcherManager fetcherManager;
 
-    private int nextRequestIndex = 0;
+    private int nextListenerId = 0;
 
     public DataLayer(@NonNull final UriFetcherManager fetcherManager,
                      @NonNull final NetworkRequestStatusStore networkRequestStatusStore,
@@ -66,12 +66,12 @@ public class DataLayer extends ClientDataLayerBase {
     protected int fetchGitHubRepository(@NonNull final Integer repositoryId) {
         checkNotNull(repositoryId);
 
-        int requestId = ++nextRequestIndex;
+        int listenerId = ++nextListenerId;
 
         Intent intent = new Intent();
         intent.putExtra("serviceUriString", GitHubService.REPOSITORY.toString());
         intent.putExtra("repositoryId", repositoryId);
-        intent.putExtra("requestId", requestId);
+        intent.putExtra("listenerId", listenerId);
 
         Fetcher<Uri> fetcher = fetcherManager.findFetcher(GitHubService.REPOSITORY);
 
@@ -79,20 +79,20 @@ public class DataLayer extends ClientDataLayerBase {
             fetcher.fetch(intent);
         }
 
-        return requestId;
+        return listenerId;
     }
 
     @Override
     protected int fetchGitHubRepositorySearch(@NonNull final String searchString) {
         checkNotNull(searchString);
 
-        int requestId = ++nextRequestIndex;
+        int listenerId = ++nextListenerId;
 
         Log.d(TAG, "fetchGitHubRepositorySearch(" + searchString + ")");
         Intent intent = new Intent();
         intent.putExtra("serviceUriString", GitHubService.REPOSITORY_SEARCH.toString());
         intent.putExtra("searchString", searchString);
-        intent.putExtra("requestId", requestId);
+        intent.putExtra("listenerId", listenerId);
 
         Fetcher<Uri> fetcher = fetcherManager.findFetcher(GitHubService.REPOSITORY_SEARCH);
 
@@ -100,6 +100,6 @@ public class DataLayer extends ClientDataLayerBase {
             fetcher.fetch(intent);
         }
 
-        return requestId;
+        return listenerId;
     }
 }

--- a/appshared/src/main/java/io/reark/rxgithubapp/shared/data/ClientDataLayerBase.java
+++ b/appshared/src/main/java/io/reark/rxgithubapp/shared/data/ClientDataLayerBase.java
@@ -112,9 +112,10 @@ public abstract class ClientDataLayerBase extends DataLayerBase {
     }
 
     @NonNull
-    public Observable<DataStreamNotification<GitHubRepository>> getGitHubRepository(
-            @NonNull final Integer repositoryId) {
-        return getGitHubRepository(null, repositoryId);
+    public Observable<GitHubRepository> getGitHubRepository(@NonNull final Integer repositoryId) {
+        return gitHubRepositoryStore
+                .getOnceAndStream(repositoryId)
+                .filter(GitHubRepository::isSome);
     }
 
     @NonNull

--- a/appshared/src/main/java/io/reark/rxgithubapp/shared/data/ClientDataLayerBase.java
+++ b/appshared/src/main/java/io/reark/rxgithubapp/shared/data/ClientDataLayerBase.java
@@ -28,6 +28,8 @@ package io.reark.rxgithubapp.shared.data;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
+import java.util.UUID;
+
 import io.reark.reark.data.DataStreamNotification;
 import io.reark.reark.data.stores.interfaces.StoreInterface;
 import io.reark.reark.data.utils.DataLayerUtils;
@@ -58,6 +60,10 @@ public abstract class ClientDataLayerBase extends DataLayerBase {
         super(networkRequestStatusStore, gitHubRepositoryStore, gitHubRepositorySearchStore);
 
         this.userSettingsStore = get(userSettingsStore);
+    }
+
+    protected static int createListenerId() {
+        return UUID.randomUUID().hashCode();
     }
 
     //// REPOSITORY SEARCH
@@ -142,6 +148,8 @@ public abstract class ClientDataLayerBase extends DataLayerBase {
     }
 
     protected abstract int fetchGitHubRepository(@NonNull final Integer repositoryId);
+
+    //// GET USER SETTINGS
 
     @NonNull
     public Observable<UserSettings> getUserSettings() {

--- a/appshared/src/main/java/io/reark/rxgithubapp/shared/data/DataFunctions.java
+++ b/appshared/src/main/java/io/reark/rxgithubapp/shared/data/DataFunctions.java
@@ -45,11 +45,12 @@ public class DataFunctions {
 
     public interface GetGitHubRepository {
         @NonNull
-        Observable<GitHubRepository> call(int repositoryId);
+        Observable<DataStreamNotification<GitHubRepository>> call(int repositoryId);
     }
 
-    public interface FetchAndGetGitHubRepository extends GetGitHubRepository {
-
+    public interface FetchAndGetGitHubRepository {
+        @NonNull
+        Observable<DataStreamNotification<GitHubRepository>> call(int repositoryId);
     }
 
     public interface GetGitHubRepositorySearch {

--- a/appshared/src/main/java/io/reark/rxgithubapp/shared/data/DataFunctions.java
+++ b/appshared/src/main/java/io/reark/rxgithubapp/shared/data/DataFunctions.java
@@ -45,7 +45,7 @@ public class DataFunctions {
 
     public interface GetGitHubRepository {
         @NonNull
-        Observable<DataStreamNotification<GitHubRepository>> call(int repositoryId);
+        Observable<GitHubRepository> call(int repositoryId);
     }
 
     public interface FetchAndGetGitHubRepository {

--- a/appshared/src/main/java/io/reark/rxgithubapp/shared/network/fetchers/GitHubRepositoryFetcher.java
+++ b/appshared/src/main/java/io/reark/rxgithubapp/shared/network/fetchers/GitHubRepositoryFetcher.java
@@ -59,18 +59,16 @@ public class GitHubRepositoryFetcher extends AppFetcherBase<Uri> {
     }
 
     @Override
-    public synchronized void fetch(@NonNull final Intent intent) {
+    public synchronized void fetch(@NonNull final Intent intent, int listenerId) {
         checkNotNull(intent);
 
-        if (!intent.hasExtra("repositoryId") || !intent.hasExtra("listenerId")) {
+        if (!intent.hasExtra("repositoryId")) {
             Log.e(TAG, "Missing required fetch parameters!");
             return;
         }
 
         int repositoryId = intent.getIntExtra("repositoryId", 0);
-        int listenerId = intent.getIntExtra("listenerId", 0);
-
-        Log.d(TAG, "fetch(" + repositoryId + ")");
+        final String uri = getUniqueId(repositoryId);
 
         if (isOngoingRequest(repositoryId)) {
             Log.d(TAG, "Found an ongoing request for repository " + repositoryId);
@@ -78,7 +76,7 @@ public class GitHubRepositoryFetcher extends AppFetcherBase<Uri> {
             return;
         }
 
-        final String uri = getUniqueId(repositoryId);
+        Log.d(TAG, "fetch(" + repositoryId + ")");
 
         Subscription subscription = createNetworkObservable(repositoryId)
                 .subscribeOn(Schedulers.computation())

--- a/appshared/src/main/java/io/reark/rxgithubapp/shared/network/fetchers/GitHubRepositoryFetcher.java
+++ b/appshared/src/main/java/io/reark/rxgithubapp/shared/network/fetchers/GitHubRepositoryFetcher.java
@@ -62,13 +62,13 @@ public class GitHubRepositoryFetcher extends AppFetcherBase<Uri> {
     public synchronized void fetch(@NonNull final Intent intent) {
         checkNotNull(intent);
 
-        int repositoryId = intent.getIntExtra("repositoryId", -1);
-        int listenerId = intent.getIntExtra("listenerId", -1);
-
-        if (repositoryId < 0 || listenerId < 0) {
-            Log.e(TAG, String.format("Invalid values: repositoryId %s, listenerId %s", repositoryId, listenerId));
+        if (!intent.hasExtra("repositoryId") || !intent.hasExtra("listenerId")) {
+            Log.e(TAG, "Missing required fetch parameters!");
             return;
         }
+
+        int repositoryId = intent.getIntExtra("repositoryId", 0);
+        int listenerId = intent.getIntExtra("listenerId", 0);
 
         Log.d(TAG, "fetch(" + repositoryId + ")");
 

--- a/appshared/src/main/java/io/reark/rxgithubapp/shared/network/fetchers/GitHubRepositoryFetcher.java
+++ b/appshared/src/main/java/io/reark/rxgithubapp/shared/network/fetchers/GitHubRepositoryFetcher.java
@@ -59,7 +59,7 @@ public class GitHubRepositoryFetcher extends AppFetcherBase<Uri> {
     }
 
     @Override
-    public void fetch(@NonNull final Intent intent) {
+    public synchronized void fetch(@NonNull final Intent intent) {
         checkNotNull(intent);
 
         int repositoryId = intent.getIntExtra("repositoryId", -1);

--- a/appshared/src/main/java/io/reark/rxgithubapp/shared/network/fetchers/GitHubRepositoryFetcher.java
+++ b/appshared/src/main/java/io/reark/rxgithubapp/shared/network/fetchers/GitHubRepositoryFetcher.java
@@ -70,9 +70,10 @@ public class GitHubRepositoryFetcher extends AppFetcherBase<Uri> {
         int repositoryId = intent.getIntExtra("repositoryId", 0);
         final String uri = getUniqueId(repositoryId);
 
+        addListener(repositoryId, listenerId);
+
         if (isOngoingRequest(repositoryId)) {
             Log.d(TAG, "Found an ongoing request for repository " + repositoryId);
-            addListener(repositoryId, listenerId);
             return;
         }
 
@@ -80,13 +81,13 @@ public class GitHubRepositoryFetcher extends AppFetcherBase<Uri> {
 
         Subscription subscription = createNetworkObservable(repositoryId)
                 .subscribeOn(Schedulers.computation())
-                .doOnSubscribe(() -> startRequest(repositoryId, listenerId, uri))
+                .doOnSubscribe(() -> startRequest(repositoryId, uri))
                 .doOnError(doOnError(repositoryId, uri))
                 .doOnCompleted(() -> completeRequest(repositoryId, uri))
                 .subscribe(gitHubRepositoryStore::put,
                         e -> Log.e(TAG, "Error fetching GitHub repository " + repositoryId, e));
 
-        addRequest(repositoryId, listenerId, subscription);
+        addRequest(repositoryId, subscription);
     }
 
     @NonNull

--- a/appshared/src/main/java/io/reark/rxgithubapp/shared/network/fetchers/GitHubRepositorySearchFetcher.java
+++ b/appshared/src/main/java/io/reark/rxgithubapp/shared/network/fetchers/GitHubRepositorySearchFetcher.java
@@ -68,7 +68,7 @@ public class GitHubRepositorySearchFetcher extends AppFetcherBase<Uri> {
     }
 
     @Override
-    public void fetch(@NonNull final Intent intent) {
+    public synchronized void fetch(@NonNull final Intent intent) {
         checkNotNull(intent);
 
         String searchString = intent.getStringExtra("searchString");

--- a/appshared/src/main/java/io/reark/rxgithubapp/shared/network/fetchers/GitHubRepositorySearchFetcher.java
+++ b/appshared/src/main/java/io/reark/rxgithubapp/shared/network/fetchers/GitHubRepositorySearchFetcher.java
@@ -80,9 +80,10 @@ public class GitHubRepositorySearchFetcher extends AppFetcherBase<Uri> {
         String uri = getUniqueId(searchString);
         int requestId = searchString.hashCode();
 
+        addListener(requestId, listenerId);
+
         if (isOngoingRequest(requestId)) {
             Log.d(TAG, "Found an ongoing request for repository " + searchString);
-            addListener(requestId, listenerId);
             return;
         }
 
@@ -98,13 +99,13 @@ public class GitHubRepositorySearchFetcher extends AppFetcherBase<Uri> {
                     }
                     return new GitHubRepositorySearch(searchString, repositoryIds);
                 })
-                .doOnSubscribe(() -> startRequest(requestId, listenerId, uri))
+                .doOnSubscribe(() -> startRequest(requestId, uri))
                 .doOnCompleted(() -> completeRequest(requestId, uri))
                 .doOnError(doOnError(requestId, uri))
                 .subscribe(gitHubRepositorySearchStore::put,
                         e -> Log.e(TAG, "Error fetching GitHub repository search for '" + searchString + "'", e));
 
-        addRequest(requestId, listenerId, subscription);
+        addRequest(requestId, subscription);
     }
 
     @NonNull

--- a/appshared/src/main/java/io/reark/rxgithubapp/shared/network/fetchers/GitHubRepositorySearchFetcher.java
+++ b/appshared/src/main/java/io/reark/rxgithubapp/shared/network/fetchers/GitHubRepositorySearchFetcher.java
@@ -71,16 +71,16 @@ public class GitHubRepositorySearchFetcher extends AppFetcherBase<Uri> {
     public synchronized void fetch(@NonNull final Intent intent) {
         checkNotNull(intent);
 
-        String searchString = intent.getStringExtra("searchString");
-        int listenerId = intent.getIntExtra("listenerId", -1);
-
-        if (searchString == null || listenerId < 0) {
-            Log.e(TAG, String.format("Invalid values: searchString %s, listenerId %s", searchString, listenerId));
+        if (!intent.hasExtra("searchString") || !intent.hasExtra("listenerId")) {
+            Log.e(TAG, "Missing required fetch parameters!");
             return;
         }
 
-        Log.d(TAG, "fetch(" + searchString + ")");
+        String searchString = intent.getStringExtra("searchString");
+        int listenerId = intent.getIntExtra("listenerId", -1);
         int requestId = searchString.hashCode();
+
+        Log.d(TAG, "fetch(" + searchString + ")");
 
         if (isOngoingRequest(requestId)) {
             Log.d(TAG, "Found an ongoing request for repository " + searchString);

--- a/appshared/src/main/java/io/reark/rxgithubapp/shared/network/fetchers/GitHubRepositorySearchFetcher.java
+++ b/appshared/src/main/java/io/reark/rxgithubapp/shared/network/fetchers/GitHubRepositorySearchFetcher.java
@@ -68,19 +68,17 @@ public class GitHubRepositorySearchFetcher extends AppFetcherBase<Uri> {
     }
 
     @Override
-    public synchronized void fetch(@NonNull final Intent intent) {
+    public synchronized void fetch(@NonNull final Intent intent, int listenerId) {
         checkNotNull(intent);
 
-        if (!intent.hasExtra("searchString") || !intent.hasExtra("listenerId")) {
+        if (!intent.hasExtra("searchString")) {
             Log.e(TAG, "Missing required fetch parameters!");
             return;
         }
 
         String searchString = intent.getStringExtra("searchString");
-        int listenerId = intent.getIntExtra("listenerId", -1);
+        String uri = getUniqueId(searchString);
         int requestId = searchString.hashCode();
-
-        Log.d(TAG, "fetch(" + searchString + ")");
 
         if (isOngoingRequest(requestId)) {
             Log.d(TAG, "Found an ongoing request for repository " + searchString);
@@ -88,7 +86,7 @@ public class GitHubRepositorySearchFetcher extends AppFetcherBase<Uri> {
             return;
         }
 
-        final String uri = getUniqueId(searchString);
+        Log.d(TAG, "fetch(" + searchString + ")");
 
         Subscription subscription = createNetworkObservable(searchString)
                 .subscribeOn(Schedulers.computation())

--- a/appshared/src/main/java/io/reark/rxgithubapp/shared/viewmodels/RepositoriesViewModel.java
+++ b/appshared/src/main/java/io/reark/rxgithubapp/shared/viewmodels/RepositoriesViewModel.java
@@ -167,8 +167,6 @@ public class RepositoriesViewModel extends AbstractViewModel {
 
         return getGitHubRepository
                 .call(repositoryId)
-                .filter(DataStreamNotification::isOnNext)
-                .map(DataStreamNotification::getValue)
                 .doOnNext((repository) -> Log.v(TAG, "Received repository " + repository.getId()));
     }
 

--- a/appshared/src/main/java/io/reark/rxgithubapp/shared/viewmodels/RepositoriesViewModel.java
+++ b/appshared/src/main/java/io/reark/rxgithubapp/shared/viewmodels/RepositoriesViewModel.java
@@ -167,6 +167,8 @@ public class RepositoriesViewModel extends AbstractViewModel {
 
         return getGitHubRepository
                 .call(repositoryId)
+                .filter(DataStreamNotification::isOnNext)
+                .map(DataStreamNotification::getValue)
                 .doOnNext((repository) -> Log.v(TAG, "Received repository " + repository.getId()));
     }
 

--- a/appshared/src/main/java/io/reark/rxgithubapp/shared/viewmodels/RepositoryViewModel.java
+++ b/appshared/src/main/java/io/reark/rxgithubapp/shared/viewmodels/RepositoryViewModel.java
@@ -67,8 +67,7 @@ public class RepositoryViewModel extends AbstractViewModel {
                         .switchMap(fetchAndGetGitHubRepository::call)
                         .filter(DataStreamNotification::isOnNext)
                         .map(DataStreamNotification::getValue)
-                        .subscribe(repository)
-        );
+                        .subscribe(repository::onNext));
     }
 
     @NonNull

--- a/appshared/src/main/java/io/reark/rxgithubapp/shared/viewmodels/RepositoryViewModel.java
+++ b/appshared/src/main/java/io/reark/rxgithubapp/shared/viewmodels/RepositoryViewModel.java
@@ -27,6 +27,7 @@ package io.reark.rxgithubapp.shared.viewmodels;
 
 import android.support.annotation.NonNull;
 
+import io.reark.reark.data.DataStreamNotification;
 import io.reark.reark.viewmodels.AbstractViewModel;
 import io.reark.rxgithubapp.shared.data.DataFunctions.FetchAndGetGitHubRepository;
 import io.reark.rxgithubapp.shared.data.DataFunctions.GetUserSettings;
@@ -64,6 +65,8 @@ public class RepositoryViewModel extends AbstractViewModel {
                 getUserSettings.call()
                         .map(UserSettings::getSelectedRepositoryId)
                         .switchMap(fetchAndGetGitHubRepository::call)
+                        .filter(DataStreamNotification::isOnNext)
+                        .map(DataStreamNotification::getValue)
                         .subscribe(repository)
         );
     }

--- a/appshared/src/test/java/io/reark/rxgithubapp/shared/viewmodels/RepositoriesViewModelTest.java
+++ b/appshared/src/test/java/io/reark/rxgithubapp/shared/viewmodels/RepositoriesViewModelTest.java
@@ -32,7 +32,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import io.reark.rxgithubapp.shared.data.DataFunctions;
+import io.reark.rxgithubapp.shared.data.DataFunctions.GetGitHubRepository;
 import io.reark.rxgithubapp.shared.data.DataFunctions.GetGitHubRepositorySearch;
 import io.reark.rxgithubapp.shared.pojo.GitHubRepository;
 import io.reark.rxgithubapp.shared.pojo.GitHubRepositorySearch;
@@ -57,7 +57,7 @@ public class RepositoriesViewModelTest {
     public void setUp() {
         viewModel = new RepositoriesViewModel(
                 mock(GetGitHubRepositorySearch.class),
-                repositoryId -> Observable.just(mock(GitHubRepository.class)));
+                __ -> Observable.just(mock(GitHubRepository.class)));
     }
 
     @Test
@@ -92,7 +92,7 @@ public class RepositoriesViewModelTest {
     }
 
     @Test
-    public void testTooLittleRepositoriesReturnThoseRepositories() {
+    public void testTooFewRepositoriesReturnsThoseRepositories() {
         TestSubscriber<List<GitHubRepository>> observer = new TestSubscriber<>();
 
         viewModel.toGitHubRepositoryList()
@@ -132,7 +132,7 @@ public class RepositoriesViewModelTest {
     @Test(expected = NullPointerException.class)
     public void testThrowsNullPointerExceptionConstructedWithNullRepositorySearch() {
         //noinspection ConstantConditions
-        new RepositoriesViewModel(null, mock(DataFunctions.GetGitHubRepository.class));
+        new RepositoriesViewModel(null, mock(GetGitHubRepository.class));
     }
 
     @Test(expected = NullPointerException.class)

--- a/reark/src/main/java/io/reark/reark/network/fetchers/Fetcher.java
+++ b/reark/src/main/java/io/reark/reark/network/fetchers/Fetcher.java
@@ -28,9 +28,27 @@ package io.reark.reark.network.fetchers;
 import android.content.Intent;
 import android.support.annotation.NonNull;
 
+/**
+ * Interface for implementing Fetchers. A Fetcher is a class that fetches and stores data, usually
+ * matching a single backend API endpoint.
+ *
+ * @param <T> Type of the Service Uri used by the application.
+ */
 public interface Fetcher<T> {
+
+    /**
+     * Starts a new fetch operation.
+     *
+     * @param intent Details of the fetch.
+     */
     void fetch(@NonNull final Intent intent);
 
+    /**
+     * Returns a Service Uri of this fetcher. Service Uri is an identifier for the endpoint
+     * to which this fetcher connects.
+     *
+     * @return Service Uri of this fetcher
+     */
     @NonNull
     T getServiceUri();
 }

--- a/reark/src/main/java/io/reark/reark/network/fetchers/Fetcher.java
+++ b/reark/src/main/java/io/reark/reark/network/fetchers/Fetcher.java
@@ -40,8 +40,9 @@ public interface Fetcher<T> {
      * Starts a new fetch operation.
      *
      * @param intent Details of the fetch.
+     * @param listenerId Id of the request status listener.
      */
-    void fetch(@NonNull final Intent intent);
+    void fetch(@NonNull final Intent intent, int listenerId);
 
     /**
      * Returns a Service Uri of this fetcher. Service Uri is an identifier for the endpoint

--- a/reark/src/main/java/io/reark/reark/pojo/NetworkRequestStatus.java
+++ b/reark/src/main/java/io/reark/reark/pojo/NetworkRequestStatus.java
@@ -30,7 +30,9 @@ import android.support.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import io.reark.reark.utils.Log;
 
@@ -48,7 +50,7 @@ public final class NetworkRequestStatus {
     private static final String TAG = NetworkRequestStatus.class.getSimpleName();
 
     private static final NetworkRequestStatus NONE =
-            new NetworkRequestStatus(Collections.emptyList(), "", NETWORK_STATUS_NONE, 0, null);
+            new NetworkRequestStatus(Collections.emptySet(), "", NETWORK_STATUS_NONE, 0, null);
 
     @NonNull
     private final String uri;
@@ -81,7 +83,7 @@ public final class NetworkRequestStatus {
         }
     }
 
-    private NetworkRequestStatus(@NonNull List<Integer> listeners,
+    private NetworkRequestStatus(@NonNull Set<Integer> listeners,
                                  @NonNull String uri,
                                  @NonNull Status status,
                                  int errorCode,
@@ -155,7 +157,7 @@ public final class NetworkRequestStatus {
 
         private Status status;
 
-        private final List<Integer> listeners = new ArrayList<>(0);
+        private final Set<Integer> listeners = new HashSet<>(1);
 
         private int errorCode;
 
@@ -186,7 +188,7 @@ public final class NetworkRequestStatus {
         }
 
         @NonNull
-        public Builder listeners(@NonNull  List<Integer> listeners) {
+        public Builder listeners(@NonNull Set<Integer> listeners) {
             this.listeners.addAll(get(listeners));
             return this;
         }


### PR DESCRIPTION
This should fix issue where new requests will start with old request status if the same resource was requester earlier. Idea behind the change is to register all requests with an id, and filter the data stream notifications so that only matching ids are let through.

Additionally the request status store should be cleared at startup to avoid issues caused by duplicate ids across application restarts, but that is pending the delete PR #155.