### PR TITLE
Separate status for request completed with value change

### DIFF
--- a/appshared/src/main/java/io/reark/rxgithubapp/shared/network/GitHubService.java
+++ b/appshared/src/main/java/io/reark/rxgithubapp/shared/network/GitHubService.java
@@ -35,14 +35,15 @@ import retrofit2.http.GET;
 import retrofit2.http.Path;
 import retrofit2.http.QueryMap;
 import rx.Observable;
+import rx.Single;
 
 public interface GitHubService {
-    static Uri REPOSITORY_SEARCH = Uri.parse("github/search");
-    static Uri REPOSITORY = Uri.parse("github/repository");
+    Uri REPOSITORY_SEARCH = Uri.parse("github/search");
+    Uri REPOSITORY = Uri.parse("github/repository");
 
     @GET("/search/repositories")
-    Observable<GitHubRepositorySearchResults> search(@QueryMap Map<String, String> search);
+    Single<GitHubRepositorySearchResults> search(@QueryMap Map<String, String> search);
 
     @GET("/repositories/{id}")
-    Observable<GitHubRepository> getRepository(@Path("id") Integer id);
+    Single<GitHubRepository> getRepository(@Path("id") Integer id);
 }

--- a/appshared/src/main/java/io/reark/rxgithubapp/shared/network/NetworkApi.java
+++ b/appshared/src/main/java/io/reark/rxgithubapp/shared/network/NetworkApi.java
@@ -36,7 +36,7 @@ import okhttp3.OkHttpClient;
 import retrofit2.Retrofit;
 import retrofit2.adapter.rxjava.RxJavaCallAdapterFactory;
 import retrofit2.converter.gson.GsonConverterFactory;
-import rx.Observable;
+import rx.Single;
 
 import static io.reark.reark.utils.Preconditions.checkNotNull;
 
@@ -59,13 +59,13 @@ public class NetworkApi {
     }
 
     @NonNull
-    public Observable<List<GitHubRepository>> search(Map<String, String> search) {
+    public Single<List<GitHubRepository>> search(Map<String, String> search) {
         return gitHubService.search(search)
                             .map(GitHubRepositorySearchResults::getItems);
     }
 
     @NonNull
-    public Observable<GitHubRepository> getRepository(int id) {
+    public Single<GitHubRepository> getRepository(int id) {
         return gitHubService.getRepository(id);
     }
 }

--- a/appshared/src/main/java/io/reark/rxgithubapp/shared/viewmodels/RepositoriesViewModel.java
+++ b/appshared/src/main/java/io/reark/rxgithubapp/shared/viewmodels/RepositoriesViewModel.java
@@ -112,9 +112,9 @@ public class RepositoriesViewModel extends AbstractViewModel {
     @NonNull
     static Func1<DataStreamNotification<GitHubRepositorySearch>, ProgressStatus> toProgressStatus() {
         return notification -> {
-            if (notification.isFetchingStart()) {
+            if (notification.isOngoing()) {
                 return ProgressStatus.LOADING;
-            } else if (notification.isFetchingError()) {
+            } else if (notification.isCompletedWithError()) {
                 return ProgressStatus.ERROR;
             } else {
                 return ProgressStatus.IDLE;

--- a/appshared/src/test/java/io/reark/rxgithubapp/shared/viewmodels/RepositoriesViewModelTest.java
+++ b/appshared/src/test/java/io/reark/rxgithubapp/shared/viewmodels/RepositoriesViewModelTest.java
@@ -39,8 +39,8 @@ import io.reark.rxgithubapp.shared.pojo.GitHubRepositorySearch;
 import rx.Observable;
 import rx.observers.TestSubscriber;
 
-import static io.reark.reark.data.DataStreamNotification.fetchingError;
-import static io.reark.reark.data.DataStreamNotification.fetchingStart;
+import static io.reark.reark.data.DataStreamNotification.completedWithError;
+import static io.reark.reark.data.DataStreamNotification.ongoing;
 import static io.reark.reark.data.DataStreamNotification.onNext;
 import static io.reark.rxgithubapp.shared.viewmodels.RepositoriesViewModel.ProgressStatus.ERROR;
 import static io.reark.rxgithubapp.shared.viewmodels.RepositoriesViewModel.ProgressStatus.IDLE;
@@ -62,12 +62,12 @@ public class RepositoriesViewModelTest {
 
     @Test
     public void testStartFetchingReportedAsLoading() {
-        assertEquals(LOADING, toProgressStatus().call(fetchingStart()));
+        assertEquals(LOADING, toProgressStatus().call(ongoing()));
     }
 
     @Test
     public void testFetchingErrorReportedAsError() {
-        assertEquals(ERROR, toProgressStatus().call(fetchingError()));
+        assertEquals(ERROR, toProgressStatus().call(completedWithError(null)));
     }
 
     @Test

--- a/reark/src/main/java/io/reark/reark/data/DataStreamNotification.java
+++ b/reark/src/main/java/io/reark/reark/data/DataStreamNotification.java
@@ -33,10 +33,11 @@ import static io.reark.reark.utils.Preconditions.get;
 public final class DataStreamNotification<T> {
 
     public enum Type {
-        FETCHING_START,
-        FETCHING_COMPLETED,
-        FETCHING_ERROR,
-        ON_NEXT
+        ONGOING,
+        ON_NEXT,
+        COMPLETED_WITH_VALUE,
+        COMPLETED_WITHOUT_VALUE,
+        COMPLETED_WITH_ERROR
     }
 
     @NonNull
@@ -46,11 +47,11 @@ public final class DataStreamNotification<T> {
     private final T value;
 
     @Nullable
-    private final Throwable error;
+    private final String error;
 
-    private DataStreamNotification(@NonNull final Type type,
-                                   @Nullable final T value,
-                                   @Nullable final Throwable error) {
+    private DataStreamNotification(@NonNull Type type,
+                                   @Nullable T value,
+                                   @Nullable String error) {
         this.type = get(type);
         this.value = value;
         this.error = error;
@@ -67,13 +68,13 @@ public final class DataStreamNotification<T> {
     }
 
     @Nullable
-    public Throwable getError() {
+    public String getError() {
         return error;
     }
 
     @NonNull
-    public static<T> DataStreamNotification<T> fetchingStart() {
-        return new DataStreamNotification<>(Type.FETCHING_START, null, null);
+    public static<T> DataStreamNotification<T> ongoing() {
+        return new DataStreamNotification<>(Type.ONGOING, null, null);
     }
 
     @NonNull
@@ -82,29 +83,46 @@ public final class DataStreamNotification<T> {
     }
 
     @NonNull
-    public static<T> DataStreamNotification<T> fetchingCompleted() {
-        return new DataStreamNotification<>(Type.FETCHING_COMPLETED, null, null);
+    public static<T> DataStreamNotification<T> completedWithValue() {
+        return new DataStreamNotification<>(Type.COMPLETED_WITH_VALUE, null, null);
     }
 
     @NonNull
-    public static<T> DataStreamNotification<T> fetchingError() {
-        return new DataStreamNotification<>(Type.FETCHING_ERROR, null, null);
+    public static<T> DataStreamNotification<T> completedWithoutValue() {
+        return new DataStreamNotification<>(Type.COMPLETED_WITHOUT_VALUE, null, null);
     }
 
-    public boolean isFetchingStart() {
-        return type == Type.FETCHING_START;
+    @NonNull
+    public static<T> DataStreamNotification<T> completedWithError(@Nullable String error) {
+        return new DataStreamNotification<>(Type.COMPLETED_WITH_ERROR, null, error);
+    }
+
+    public boolean isOngoing() {
+        return type == Type.ONGOING;
     }
 
     public boolean isOnNext() {
         return type == Type.ON_NEXT;
     }
 
-    public boolean isFetchingCompleted() {
-        return type == Type.FETCHING_COMPLETED;
+    public boolean isCompletedWithValue() {
+        return type == Type.COMPLETED_WITH_VALUE;
     }
 
-    public boolean isFetchingError() {
-        return type == Type.FETCHING_ERROR;
+    public boolean isCompletedWithoutValue() {
+        return type == Type.COMPLETED_WITHOUT_VALUE;
+    }
+
+    public boolean isCompletedWithError() {
+        return type == Type.COMPLETED_WITH_ERROR;
+    }
+
+    public boolean isCompletedWithSuccess() {
+        return isCompletedWithValue() || isCompletedWithoutValue();
+    }
+
+    public boolean isCompleted() {
+        return isCompletedWithSuccess() || isCompletedWithError();
     }
 
     @Override

--- a/reark/src/main/java/io/reark/reark/data/stores/cores/ContentProviderStoreCoreBase.java
+++ b/reark/src/main/java/io/reark/reark/data/stores/cores/ContentProviderStoreCoreBase.java
@@ -59,6 +59,7 @@ import rx.subjects.PublishSubject;
 import rx.subjects.Subject;
 
 import static io.reark.reark.utils.Preconditions.checkNotNull;
+import static io.reark.reark.utils.Preconditions.get;
 
 /**
  * ContentProviderStoreCoreBase implements an Observable based item store that uses a content provider as
@@ -315,15 +316,12 @@ public abstract class ContentProviderStoreCoreBase<U> {
 
     @NonNull
     protected Observable<List<U>> getAllOnce(@NonNull final Uri uri) {
-        checkNotNull(uri);
-
-        return Observable.fromCallable(() -> queryList(uri))
-                .subscribeOn(Schedulers.io());
+        return Observable.fromCallable(() -> queryList(get(uri)));
     }
 
     @NonNull
     protected Observable<U> getOnce(@NonNull final Uri uri) {
-        return getAllOnce(Preconditions.get(uri))
+        return getAllOnce(get(uri))
                 .filter(list -> !list.isEmpty())
                 .doOnNext(list -> {
                     if (list.size() > 1) {

--- a/reark/src/main/java/io/reark/reark/data/utils/DataLayerUtils.java
+++ b/reark/src/main/java/io/reark/reark/data/utils/DataLayerUtils.java
@@ -59,15 +59,18 @@ public final class DataLayerUtils {
             checkNotNull(networkRequestStatus);
 
             switch (networkRequestStatus.getStatus()) {
-                case NETWORK_STATUS_ONGOING:
-                    return DataStreamNotification.fetchingStart();
-                case NETWORK_STATUS_COMPLETED:
-                    return DataStreamNotification.fetchingCompleted();
-                case NETWORK_STATUS_ERROR:
-                    return DataStreamNotification.fetchingError();
+                case ONGOING:
+                    return DataStreamNotification.ongoing();
+                case COMPLETED_WITH_VALUE:
+                    return DataStreamNotification.completedWithValue();
+                case COMPLETED_WITHOUT_VALUE:
+                    return DataStreamNotification.completedWithoutValue();
+                case COMPLETED_WITH_ERROR:
+                    return DataStreamNotification.completedWithError(networkRequestStatus.getErrorMessage());
+                case NONE:
+                default:
+                    throw new IllegalStateException("Unexpected network status " + networkRequestStatus);
             }
-
-            throw new IllegalStateException("Unexpected network status " + networkRequestStatus);
         };
     }
 }

--- a/reark/src/main/java/io/reark/reark/network/fetchers/FetcherBase.java
+++ b/reark/src/main/java/io/reark/reark/network/fetchers/FetcherBase.java
@@ -27,7 +27,6 @@ package io.reark.reark.network.fetchers;
 
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-import android.support.v4.util.Pair;
 
 import java.util.HashSet;
 import java.util.Map;
@@ -86,15 +85,15 @@ public abstract class FetcherBase<T> implements Fetcher<T> {
         release(requestId);
     }
 
-    protected void completeRequest(int requestId, @NonNull String uri) {
-        Log.v(TAG, String.format("completeRequest(%s, %s)", requestId, get(uri)));
+    protected void completeRequest(int requestId, @NonNull String uri, boolean withValue) {
+        Log.v(TAG, String.format("completeRequest(%s, %s, %s)", requestId, get(uri), withValue));
 
         lock(requestId);
 
         updateNetworkRequestStatus.call(new NetworkRequestStatus.Builder()
                 .uri(uri)
                 .listeners(getListeners(requestId))
-                .completed()
+                .completed(withValue)
                 .build());
 
         release(requestId);
@@ -187,7 +186,7 @@ public abstract class FetcherBase<T> implements Fetcher<T> {
                 int statusCode = httpException.code();
                 errorRequest(requestId, uri, statusCode, httpException.getMessage());
             } else {
-                Log.w(TAG, "The error was not a RetrofitError");
+                Log.w(TAG, "The error was not a RetrofitError", throwable);
                 errorRequest(requestId, uri, NO_ERROR_CODE, null);
             }
         };

--- a/reark/src/main/java/io/reark/reark/pojo/NetworkRequestStatus.java
+++ b/reark/src/main/java/io/reark/reark/pojo/NetworkRequestStatus.java
@@ -34,12 +34,14 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import static io.reark.reark.pojo.NetworkRequestStatus.Status.COMPLETED_WITHOUT_VALUE;
+import static io.reark.reark.pojo.NetworkRequestStatus.Status.COMPLETED_WITH_ERROR;
+import static io.reark.reark.pojo.NetworkRequestStatus.Status.COMPLETED_WITH_VALUE;
+import static io.reark.reark.pojo.NetworkRequestStatus.Status.NONE;
+import static io.reark.reark.pojo.NetworkRequestStatus.Status.ONGOING;
+
 import io.reark.reark.utils.Log;
 
-import static io.reark.reark.pojo.NetworkRequestStatus.Status.NETWORK_STATUS_COMPLETED;
-import static io.reark.reark.pojo.NetworkRequestStatus.Status.NETWORK_STATUS_ERROR;
-import static io.reark.reark.pojo.NetworkRequestStatus.Status.NETWORK_STATUS_NONE;
-import static io.reark.reark.pojo.NetworkRequestStatus.Status.NETWORK_STATUS_ONGOING;
 import static io.reark.reark.utils.Preconditions.get;
 
 /**
@@ -49,8 +51,8 @@ public final class NetworkRequestStatus {
 
     private static final String TAG = NetworkRequestStatus.class.getSimpleName();
 
-    private static final NetworkRequestStatus NONE =
-            new NetworkRequestStatus(Collections.emptySet(), "", NETWORK_STATUS_NONE, 0, null);
+    private static final NetworkRequestStatus NO_STATUS =
+            new NetworkRequestStatus(Collections.emptySet(), "", NONE, 0, null);
 
     @NonNull
     private final String uri;
@@ -67,10 +69,11 @@ public final class NetworkRequestStatus {
     private final String errorMessage;
 
     public enum Status {
-        NETWORK_STATUS_NONE("networkStatusNone"),
-        NETWORK_STATUS_ONGOING("networkStatusOngoing"),
-        NETWORK_STATUS_COMPLETED("networkStatusCompleted"),
-        NETWORK_STATUS_ERROR("networkStatusError");
+        NONE("none"),
+        ONGOING("ongoing"),
+        COMPLETED_WITH_VALUE("completedWithValue"),
+        COMPLETED_WITHOUT_VALUE("completedWithoutValue"),
+        COMPLETED_WITH_ERROR("completedWithError");
 
         private final String status;
 
@@ -97,7 +100,7 @@ public final class NetworkRequestStatus {
 
     @NonNull
     public static NetworkRequestStatus none() {
-        return NONE;
+        return NO_STATUS;
     }
 
     @NonNull
@@ -124,23 +127,27 @@ public final class NetworkRequestStatus {
     }
 
     public boolean isSome() {
-        return status != NETWORK_STATUS_NONE;
+        return status != NONE;
     }
 
     public boolean isNone() {
-        return status == NETWORK_STATUS_NONE;
+        return status == NONE;
     }
 
     public boolean isOngoing() {
-        return status == NETWORK_STATUS_ONGOING;
+        return status == ONGOING;
     }
 
-    public boolean isError() {
-        return status == NETWORK_STATUS_ERROR;
+    public boolean isCompletedWithValue() {
+        return status == COMPLETED_WITH_VALUE;
     }
 
-    public boolean isCompleted() {
-        return status == NETWORK_STATUS_COMPLETED;
+    public boolean isCompletedWithoutValue() {
+        return status == COMPLETED_WITHOUT_VALUE;
+    }
+
+    public boolean isCompletedWithError() {
+        return status == COMPLETED_WITH_ERROR;
     }
 
     @Override
@@ -165,19 +172,19 @@ public final class NetworkRequestStatus {
 
         @NonNull
         public Builder ongoing() {
-            this.status = NETWORK_STATUS_ONGOING;
+            this.status = ONGOING;
             return this;
         }
 
         @NonNull
         public Builder error() {
-            this.status = NETWORK_STATUS_ERROR;
+            this.status = COMPLETED_WITH_ERROR;
             return this;
         }
 
         @NonNull
-        public Builder completed() {
-            this.status = NETWORK_STATUS_COMPLETED;
+        public Builder completed(boolean withValue) {
+            this.status = withValue ? COMPLETED_WITH_VALUE : COMPLETED_WITHOUT_VALUE;
             return this;
         }
 


### PR DESCRIPTION
A successful fetch may not change data, in which case observers won't get notified of a change and no ON_NEXT will be emitted. Thus, completed with/without value should be separate states so that any value listeners can decide to end a subscription. Currently that's not possible as they have to keep waiting for ON_NEXT that may or may not come.