### PR TITLE
Fix content operation result notification mechanism

### DIFF
--- a/reark/src/main/java/io/reark/reark/data/stores/cores/ContentProviderStoreCoreBase.java
+++ b/reark/src/main/java/io/reark/reark/data/stores/cores/ContentProviderStoreCoreBase.java
@@ -175,7 +175,8 @@ public abstract class ContentProviderStoreCoreBase<U> {
                 Observable.merge(
                         stream.window(groupMaxSize).skip(1),
                         stream.debounce(groupingTimeout, TimeUnit.MILLISECONDS))))
-                .filter(list -> !list.isEmpty());
+                .filter(list -> !list.isEmpty())
+                .onBackpressureBuffer();
     }
 
     @NonNull
@@ -307,6 +308,8 @@ public abstract class ContentProviderStoreCoreBase<U> {
 
     @NonNull
     protected Observable<List<U>> getAllOnce(@NonNull final Uri uri) {
+        checkNotNull(uri);
+
         return Observable.fromCallable(() -> queryList(uri))
                 .subscribeOn(Schedulers.io());
     }

--- a/reark/src/main/java/io/reark/reark/data/stores/cores/ContentProviderStoreCoreBase.java
+++ b/reark/src/main/java/io/reark/reark/data/stores/cores/ContentProviderStoreCoreBase.java
@@ -291,29 +291,29 @@ public abstract class ContentProviderStoreCoreBase<U> {
         checkNotNull(item);
         checkNotNull(uri);
 
-        return createModifyingOperation(index -> CoreValuePut.create(index, uri, item));
+        return createModifyingOperation(id -> CoreValuePut.create(id, uri, item));
     }
 
     @NonNull
     protected Single<Boolean> delete(@NonNull final Uri uri) {
         checkNotNull(uri);
 
-        return createModifyingOperation(index -> CoreValueDelete.create(index, uri));
+        return createModifyingOperation(id -> CoreValueDelete.create(id, uri));
     }
 
     @NonNull
     private Single<Boolean> createModifyingOperation(@NonNull final Func1<Integer, CoreValue<U>> valueFunc) {
-        int index = createIndex();
+        int id = createId();
 
-        completionNotifiers.put(index, PublishSubject.create());
-        operationSubject.onNext(valueFunc.call(index));
+        completionNotifiers.put(id, PublishSubject.create());
+        operationSubject.onNext(valueFunc.call(id));
 
-        return completionNotifiers.get(index)
+        return completionNotifiers.get(id)
                 .first()
                 .toSingle();
     }
 
-    private static int createIndex() {
+    private static int createId() {
         return UUID.randomUUID().hashCode();
     }
 

--- a/reark/src/main/java/io/reark/reark/data/stores/cores/ContentProviderStoreCoreBase.java
+++ b/reark/src/main/java/io/reark/reark/data/stores/cores/ContentProviderStoreCoreBase.java
@@ -38,6 +38,7 @@ import android.support.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
@@ -99,8 +100,6 @@ public abstract class ContentProviderStoreCoreBase<U> {
     private final int groupMaxSize;
 
     private final int groupingTimeout;
-
-    private int nextOperationIndex = 0;
 
     protected ContentProviderStoreCoreBase(@NonNull final ContentResolver contentResolver) {
         this(contentResolver, DEFAULT_GROUPING_TIMEOUT_MS, DEFAULT_GROUP_MAX_SIZE);
@@ -304,7 +303,7 @@ public abstract class ContentProviderStoreCoreBase<U> {
 
     @NonNull
     private Single<Boolean> createModifyingOperation(@NonNull final Func1<Integer, CoreValue<U>> valueFunc) {
-        int index = ++nextOperationIndex;
+        int index = createIndex();
 
         completionNotifiers.put(index, PublishSubject.create());
         operationSubject.onNext(valueFunc.call(index));
@@ -314,9 +313,14 @@ public abstract class ContentProviderStoreCoreBase<U> {
                 .toSingle();
     }
 
+    private static int createIndex() {
+        return UUID.randomUUID().hashCode();
+    }
+
     @NonNull
     protected Observable<List<U>> getAllOnce(@NonNull final Uri uri) {
-        return Observable.fromCallable(() -> queryList(get(uri)));
+        return Observable.fromCallable(() -> queryList(uri))
+                .subscribeOn(Schedulers.io());
     }
 
     @NonNull

--- a/reark/src/main/java/io/reark/reark/data/stores/cores/operations/CoreOperation.java
+++ b/reark/src/main/java/io/reark/reark/data/stores/cores/operations/CoreOperation.java
@@ -44,18 +44,18 @@ public final class CoreOperation {
     private final Uri uri;
 
     @NonNull
-    private final Subject<Boolean, Boolean> subject;
+    private final Subject<Boolean, Boolean> completionNotifier;
 
     @NonNull
     private final ContentProviderOperation operation;
 
-    CoreOperation(@NonNull Uri uri, @NonNull Subject<Boolean, Boolean> subject) {
-        this(uri, subject, NO_OP);
+    CoreOperation(@NonNull Uri uri, @NonNull Subject<Boolean, Boolean> completionNotifier) {
+        this(uri, completionNotifier, NO_OP);
     }
 
-    CoreOperation(@NonNull Uri uri, @NonNull Subject<Boolean, Boolean> subject, @NonNull ContentProviderOperation operation) {
+    CoreOperation(@NonNull Uri uri, @NonNull Subject<Boolean, Boolean> completionNotifier, @NonNull ContentProviderOperation operation) {
         this.uri = uri;
-        this.subject = subject;
+        this.completionNotifier = completionNotifier;
         this.operation = operation;
     }
 
@@ -65,8 +65,8 @@ public final class CoreOperation {
     }
 
     @NonNull
-    public Subject<Boolean, Boolean> subject() {
-        return subject;
+    public Subject<Boolean, Boolean> completionNotifier() {
+        return completionNotifier;
     }
 
     @NonNull

--- a/reark/src/main/java/io/reark/reark/data/stores/cores/operations/CoreOperation.java
+++ b/reark/src/main/java/io/reark/reark/data/stores/cores/operations/CoreOperation.java
@@ -29,6 +29,8 @@ import android.content.ContentProviderOperation;
 import android.net.Uri;
 import android.support.annotation.NonNull;
 
+import rx.subjects.Subject;
+
 /**
  * A class wrapping ContentProviderOperation, the operation Uri, and operation identifier.
  */
@@ -38,31 +40,33 @@ public final class CoreOperation {
     private static final ContentProviderOperation NO_OP =
             ContentProviderOperation.newInsert(Uri.EMPTY).build();
 
-    private final int id;
-
     @NonNull
     private final Uri uri;
 
     @NonNull
+    private final Subject<Boolean, Boolean> subject;
+
+    @NonNull
     private final ContentProviderOperation operation;
 
-    CoreOperation(int id, @NonNull Uri uri) {
-        this(id, uri, NO_OP);
+    CoreOperation(@NonNull Uri uri, @NonNull Subject<Boolean, Boolean> subject) {
+        this(uri, subject, NO_OP);
     }
 
-    CoreOperation(int id, @NonNull Uri uri, @NonNull ContentProviderOperation operation) {
-        this.id = id;
+    CoreOperation(@NonNull Uri uri, @NonNull Subject<Boolean, Boolean> subject, @NonNull ContentProviderOperation operation) {
         this.uri = uri;
+        this.subject = subject;
         this.operation = operation;
-    }
-
-    public int id() {
-        return id;
     }
 
     @NonNull
     public Uri uri() {
         return uri;
+    }
+
+    @NonNull
+    public Subject<Boolean, Boolean> subject() {
+        return subject;
     }
 
     @NonNull

--- a/reark/src/main/java/io/reark/reark/data/stores/cores/operations/CoreOperationResult.java
+++ b/reark/src/main/java/io/reark/reark/data/stores/cores/operations/CoreOperationResult.java
@@ -37,19 +37,19 @@ public final class CoreOperationResult {
     private final Uri uri;
 
     @NonNull
-    private final Subject<Boolean, Boolean> subject;
+    private final Subject<Boolean, Boolean> completionNotifier;
 
     private final boolean success;
 
     public CoreOperationResult(@NonNull CoreOperation operation, boolean success) {
         this.uri = operation.uri();
-        this.subject = operation.subject();
+        this.completionNotifier = operation.completionNotifier();
         this.success = success;
     }
 
     public CoreOperationResult(@NonNull ContentProviderResult result, @NonNull CoreOperation operation) {
         this.uri = operation.uri();
-        this.subject = operation.subject();
+        this.completionNotifier = operation.completionNotifier();
         this.success = result.count == null || result.count > 0;
     }
 
@@ -58,13 +58,7 @@ public final class CoreOperationResult {
         return uri;
     }
 
-    @NonNull
-    public Subject<Boolean, Boolean> subject() {
-        return subject;
+    public void notifyCompletion() {
+        completionNotifier.onNext(success);
     }
-
-    public boolean success() {
-        return success;
-    }
-
 }

--- a/reark/src/main/java/io/reark/reark/data/stores/cores/operations/CoreOperationResult.java
+++ b/reark/src/main/java/io/reark/reark/data/stores/cores/operations/CoreOperationResult.java
@@ -29,34 +29,38 @@ import android.content.ContentProviderResult;
 import android.net.Uri;
 import android.support.annotation.NonNull;
 
-public final class CoreOperationResult {
+import rx.subjects.Subject;
 
-    private final int id;
+public final class CoreOperationResult {
 
     @NonNull
     private final Uri uri;
 
+    @NonNull
+    private final Subject<Boolean, Boolean> subject;
+
     private final boolean success;
 
     public CoreOperationResult(@NonNull CoreOperation operation, boolean success) {
-        this.id = operation.id();
         this.uri = operation.uri();
+        this.subject = operation.subject();
         this.success = success;
     }
 
     public CoreOperationResult(@NonNull ContentProviderResult result, @NonNull CoreOperation operation) {
-        this.id = operation.id();
         this.uri = operation.uri();
+        this.subject = operation.subject();
         this.success = result.count == null || result.count > 0;
-    }
-
-    public int id() {
-        return id;
     }
 
     @NonNull
     public Uri uri() {
         return uri;
+    }
+
+    @NonNull
+    public Subject<Boolean, Boolean> subject() {
+        return subject;
     }
 
     public boolean success() {

--- a/reark/src/main/java/io/reark/reark/data/stores/cores/operations/CoreValue.java
+++ b/reark/src/main/java/io/reark/reark/data/stores/cores/operations/CoreValue.java
@@ -41,13 +41,13 @@ public interface CoreValue<U> {
     }
 
     @NonNull
-    Subject<Boolean, Boolean> subject();
-
-    @NonNull
     Uri uri();
 
     @NonNull
     Type type();
+
+    @NonNull
+    Subject<Boolean, Boolean> completionNotifier();
 
     @NonNull
     CoreOperation noOperation();

--- a/reark/src/main/java/io/reark/reark/data/stores/cores/operations/CoreValue.java
+++ b/reark/src/main/java/io/reark/reark/data/stores/cores/operations/CoreValue.java
@@ -28,6 +28,8 @@ package io.reark.reark.data.stores.cores.operations;
 import android.net.Uri;
 import android.support.annotation.NonNull;
 
+import rx.subjects.Subject;
+
 /**
  * Interface holding the type of data update.
  */
@@ -38,7 +40,8 @@ public interface CoreValue<U> {
         DELETE
     }
 
-    int id();
+    @NonNull
+    Subject<Boolean, Boolean> subject();
 
     @NonNull
     Uri uri();

--- a/reark/src/main/java/io/reark/reark/data/stores/cores/operations/CoreValueDelete.java
+++ b/reark/src/main/java/io/reark/reark/data/stores/cores/operations/CoreValueDelete.java
@@ -29,40 +29,44 @@ import android.content.ContentProviderOperation;
 import android.net.Uri;
 import android.support.annotation.NonNull;
 
+import rx.subjects.Subject;
+
 /**
  * A class used to represent a deletion from the database.
  */
 public final class CoreValueDelete<U> implements CoreValue<U> {
 
-    private final int id;
-
     @NonNull
     private final Uri uri;
 
-    private CoreValueDelete(int id, @NonNull Uri uri) {
-        this.id = id;
+    @NonNull
+    private final Subject<Boolean, Boolean> subject;
+
+    private CoreValueDelete(@NonNull Uri uri, @NonNull Subject<Boolean, Boolean> subject) {
         this.uri = uri;
+        this.subject = subject;
     }
 
     @NonNull
-    public static <U> CoreValueDelete<U> create(int id, @NonNull Uri uri) {
-        return new CoreValueDelete<>(id, uri);
+    public static <U> CoreValueDelete<U> create(@NonNull Subject<Boolean, Boolean> subject, @NonNull Uri uri) {
+        return new CoreValueDelete<>(uri, subject);
     }
 
     @NonNull
     public CoreOperation toDeleteOperation() {
-        return new CoreOperation(id, uri, ContentProviderOperation.newDelete(uri).build());
+        return new CoreOperation(uri, subject, ContentProviderOperation.newDelete(uri).build());
     }
 
     @Override
     @NonNull
     public CoreOperation noOperation() {
-        return new CoreOperation(id, uri);
+        return new CoreOperation(uri, subject);
     }
 
+    @NonNull
     @Override
-    public int id() {
-        return id;
+    public Subject<Boolean, Boolean> subject() {
+        return subject;
     }
 
     @Override

--- a/reark/src/main/java/io/reark/reark/data/stores/cores/operations/CoreValueDelete.java
+++ b/reark/src/main/java/io/reark/reark/data/stores/cores/operations/CoreValueDelete.java
@@ -40,33 +40,21 @@ public final class CoreValueDelete<U> implements CoreValue<U> {
     private final Uri uri;
 
     @NonNull
-    private final Subject<Boolean, Boolean> subject;
+    private final Subject<Boolean, Boolean> completionNotifier;
 
-    private CoreValueDelete(@NonNull Uri uri, @NonNull Subject<Boolean, Boolean> subject) {
+    private CoreValueDelete(@NonNull Uri uri, @NonNull Subject<Boolean, Boolean> completionNotifier) {
         this.uri = uri;
-        this.subject = subject;
+        this.completionNotifier = completionNotifier;
     }
 
     @NonNull
-    public static <U> CoreValueDelete<U> create(@NonNull Subject<Boolean, Boolean> subject, @NonNull Uri uri) {
-        return new CoreValueDelete<>(uri, subject);
+    public static <U> CoreValueDelete<U> create(@NonNull Subject<Boolean, Boolean> completionNotifier, @NonNull Uri uri) {
+        return new CoreValueDelete<>(uri, completionNotifier);
     }
 
     @NonNull
     public CoreOperation toDeleteOperation() {
-        return new CoreOperation(uri, subject, ContentProviderOperation.newDelete(uri).build());
-    }
-
-    @Override
-    @NonNull
-    public CoreOperation noOperation() {
-        return new CoreOperation(uri, subject);
-    }
-
-    @NonNull
-    @Override
-    public Subject<Boolean, Boolean> subject() {
-        return subject;
+        return new CoreOperation(uri, completionNotifier, ContentProviderOperation.newDelete(uri).build());
     }
 
     @Override
@@ -79,6 +67,18 @@ public final class CoreValueDelete<U> implements CoreValue<U> {
     @Override
     public Type type() {
         return Type.DELETE;
+    }
+
+    @NonNull
+    @Override
+    public Subject<Boolean, Boolean> completionNotifier() {
+        return completionNotifier;
+    }
+
+    @Override
+    @NonNull
+    public CoreOperation noOperation() {
+        return new CoreOperation(uri, completionNotifier);
     }
 
 }

--- a/reark/src/main/java/io/reark/reark/data/stores/cores/operations/CoreValuePut.java
+++ b/reark/src/main/java/io/reark/reark/data/stores/cores/operations/CoreValuePut.java
@@ -30,12 +30,12 @@ import android.content.ContentValues;
 import android.net.Uri;
 import android.support.annotation.NonNull;
 
+import rx.subjects.Subject;
+
 /**
  * A class used to represent a change to the database.
  */
 public final class CoreValuePut<U> implements CoreValue<U> {
-
-    private final int id;
 
     @NonNull
     private final Uri uri;
@@ -43,20 +43,23 @@ public final class CoreValuePut<U> implements CoreValue<U> {
     @NonNull
     private final U item;
 
-    private CoreValuePut(int id, @NonNull Uri uri, @NonNull U item) {
-        this.id = id;
+    @NonNull
+    private final Subject<Boolean, Boolean> subject;
+
+    private CoreValuePut(@NonNull Uri uri, @NonNull U item, @NonNull Subject<Boolean, Boolean> subject) {
         this.uri = uri;
         this.item = item;
+        this.subject = subject;
     }
 
     @NonNull
-    public static <U> CoreValuePut<U> create(int id, @NonNull Uri uri, @NonNull U item) {
-        return new CoreValuePut<>(id, uri, item);
+    public static <U> CoreValuePut<U> create(@NonNull Subject<Boolean, Boolean> subject, @NonNull Uri uri, @NonNull U item) {
+        return new CoreValuePut<>(uri, item, subject);
     }
 
     @NonNull
     public CoreOperation toInsertOperation(@NonNull ContentValues values) {
-        return new CoreOperation(id, uri, ContentProviderOperation
+        return new CoreOperation(uri, subject, ContentProviderOperation
                 .newInsert(uri)
                 .withValues(values)
                 .build());
@@ -64,7 +67,7 @@ public final class CoreValuePut<U> implements CoreValue<U> {
 
     @NonNull
     public CoreOperation toUpdateOperation(@NonNull ContentValues values) {
-        return new CoreOperation(id, uri, ContentProviderOperation
+        return new CoreOperation(uri, subject, ContentProviderOperation
                 .newUpdate(uri)
                 .withValues(values)
                 .build());
@@ -73,12 +76,13 @@ public final class CoreValuePut<U> implements CoreValue<U> {
     @Override
     @NonNull
     public CoreOperation noOperation() {
-        return new CoreOperation(id, uri);
+        return new CoreOperation(uri, subject);
     }
 
+    @NonNull
     @Override
-    public int id() {
-        return id;
+    public Subject<Boolean, Boolean> subject() {
+        return subject;
     }
 
     @Override

--- a/reark/src/main/java/io/reark/reark/data/stores/cores/operations/CoreValuePut.java
+++ b/reark/src/main/java/io/reark/reark/data/stores/cores/operations/CoreValuePut.java
@@ -44,22 +44,22 @@ public final class CoreValuePut<U> implements CoreValue<U> {
     private final U item;
 
     @NonNull
-    private final Subject<Boolean, Boolean> subject;
+    private final Subject<Boolean, Boolean> completionNotifier;
 
-    private CoreValuePut(@NonNull Uri uri, @NonNull U item, @NonNull Subject<Boolean, Boolean> subject) {
+    private CoreValuePut(@NonNull Uri uri, @NonNull U item, @NonNull Subject<Boolean, Boolean> completionNotifier) {
         this.uri = uri;
         this.item = item;
-        this.subject = subject;
+        this.completionNotifier = completionNotifier;
     }
 
     @NonNull
-    public static <U> CoreValuePut<U> create(@NonNull Subject<Boolean, Boolean> subject, @NonNull Uri uri, @NonNull U item) {
-        return new CoreValuePut<>(uri, item, subject);
+    public static <U> CoreValuePut<U> create(@NonNull Subject<Boolean, Boolean> completionNotifier, @NonNull Uri uri, @NonNull U item) {
+        return new CoreValuePut<>(uri, item, completionNotifier);
     }
 
     @NonNull
     public CoreOperation toInsertOperation(@NonNull ContentValues values) {
-        return new CoreOperation(uri, subject, ContentProviderOperation
+        return new CoreOperation(uri, completionNotifier, ContentProviderOperation
                 .newInsert(uri)
                 .withValues(values)
                 .build());
@@ -67,22 +67,10 @@ public final class CoreValuePut<U> implements CoreValue<U> {
 
     @NonNull
     public CoreOperation toUpdateOperation(@NonNull ContentValues values) {
-        return new CoreOperation(uri, subject, ContentProviderOperation
+        return new CoreOperation(uri, completionNotifier, ContentProviderOperation
                 .newUpdate(uri)
                 .withValues(values)
                 .build());
-    }
-
-    @Override
-    @NonNull
-    public CoreOperation noOperation() {
-        return new CoreOperation(uri, subject);
-    }
-
-    @NonNull
-    @Override
-    public Subject<Boolean, Boolean> subject() {
-        return subject;
     }
 
     @Override
@@ -100,6 +88,18 @@ public final class CoreValuePut<U> implements CoreValue<U> {
     @Override
     public Type type() {
         return Type.PUT;
+    }
+
+    @NonNull
+    @Override
+    public Subject<Boolean, Boolean> completionNotifier() {
+        return completionNotifier;
+    }
+
+    @Override
+    @NonNull
+    public CoreOperation noOperation() {
+        return new CoreOperation(uri, completionNotifier);
     }
 
 }


### PR DESCRIPTION
Fixes content operation result listening mechanism that was prone to race conditions with id put/get. Keeping the result notification subject with the operation avoids the problem entirely.

Additionally fixes threading that wasn't properly applied, and adds missing backpressure handling that was revealed with the improved performance after applying proper threading.