### PR TITLE
Fix grouping logic failure when number of items matches the group size

### DIFF
--- a/app/src/main/java/io/reark/rxgithubapp/advanced/data/stores/cores/NetworkRequestStatusStoreCore.java
+++ b/app/src/main/java/io/reark/rxgithubapp/advanced/data/stores/cores/NetworkRequestStatusStoreCore.java
@@ -60,7 +60,7 @@ public class NetworkRequestStatusStoreCore extends ContentProviderStoreCore<Inte
 
     @NonNull
     @Override
-    protected Observable<List<CoreOperation>> groupOperations(@NonNull final Observable<CoreOperation> source) {
+    protected <R> Observable<List<R>> groupOperations(@NonNull Observable<R> source) {
         // NetworkRequestStatus updates should not be grouped to ensure fast processing.
         return source.map(Collections::singletonList);
     }

--- a/reark/src/main/java/io/reark/reark/data/stores/cores/ContentProviderStoreCoreBase.java
+++ b/reark/src/main/java/io/reark/reark/data/stores/cores/ContentProviderStoreCoreBase.java
@@ -170,15 +170,18 @@ public abstract class ContentProviderStoreCoreBase<U> {
     /**
      * Implements grouping logic for batching the content provider operations. The default
      * logic buffers the operations with debounced timer while applying a hard limit for the
-     * number of operations. The data is serialized into a binder transaction. An attempt
-     * to pass a too large batch of operations will result in a failed binder transaction.
+     * number of operations.
+     *
+     * The data is serialized into a binder transaction. An attempt to pass here a too large
+     * batch of operations will result in a failed binder transaction.
      */
     @NonNull
     protected <R> Observable<List<R>> groupOperations(@NonNull final Observable<R> source) {
         return source.publish(stream -> stream.buffer(
                 Observable.merge(
                         stream.window(groupMaxSize).skip(1),
-                        stream.debounce(groupingTimeout, TimeUnit.MILLISECONDS))));
+                        stream.debounce(groupingTimeout, TimeUnit.MILLISECONDS))))
+                .filter(list -> !list.isEmpty());
     }
 
     @NonNull

--- a/reark/src/main/java/io/reark/reark/data/stores/cores/ContentProviderStoreCoreBase.java
+++ b/reark/src/main/java/io/reark/reark/data/stores/cores/ContentProviderStoreCoreBase.java
@@ -76,9 +76,9 @@ public abstract class ContentProviderStoreCoreBase<U> {
 
     private final String TAG = getClass().getSimpleName();
 
-    public static final int DEFAULT_GROUPING_TIMEOUT_MS = 100;
+    static final int DEFAULT_GROUPING_TIMEOUT_MS = 100;
 
-    public static final int DEFAULT_GROUP_MAX_SIZE = 30;
+    static final int DEFAULT_GROUP_MAX_SIZE = 30;
 
     @NonNull
     private final ContentResolver contentResolver;

--- a/reark/src/test/java/io/reark/reark/data/stores/cores/ContentProviderStoreCoreBaseTest.java
+++ b/reark/src/test/java/io/reark/reark/data/stores/cores/ContentProviderStoreCoreBaseTest.java
@@ -1,0 +1,127 @@
+package io.reark.reark.data.stores.cores;
+
+import android.content.ContentResolver;
+import android.content.ContentValues;
+import android.database.ContentObserver;
+import android.database.Cursor;
+import android.net.Uri;
+import android.support.annotation.NonNull;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.concurrent.TimeUnit;
+
+import rx.Emitter.BackpressureMode;
+import rx.Observable;
+
+import static io.reark.reark.data.stores.cores.ContentProviderStoreCoreBase.DEFAULT_GROUPING_TIMEOUT_MS;
+import static io.reark.reark.data.stores.cores.ContentProviderStoreCoreBase.DEFAULT_GROUP_MAX_SIZE;
+
+public class ContentProviderStoreCoreBaseTest {
+
+    private ContentProviderStoreCoreBase<Integer> contentStoreCore;
+
+    @Before
+    public void setup() {
+        contentStoreCore = new NullContentStore();
+    }
+
+    private static Observable<Integer> createSource(int numItems) {
+        return Observable.fromEmitter(publisher -> {
+            for (int i = 1; i <= numItems; i++) {
+                publisher.onNext(i);
+            }
+        }, BackpressureMode.BUFFER);
+    }
+
+    @Test
+    public void groupOperations_WithNoElements_DoesNotEmit() {
+        contentStoreCore.groupOperations(Observable.never())
+                .test()
+                .awaitTerminalEvent(2 * DEFAULT_GROUPING_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+                .assertNotCompleted()
+                .assertNoValues();
+    }
+
+    @Test
+    public void groupOperations_WithOneElement_EmitsOneGroup() {
+        contentStoreCore.groupOperations(createSource(1))
+                .test()
+                .awaitTerminalEvent(2 * DEFAULT_GROUPING_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+                .assertNotCompleted()
+                .assertValueCount(1);
+    }
+
+    @Test
+    public void groupOperations_WithGroupMaxSizeElements_EmitsOneGroup() {
+        contentStoreCore.groupOperations(createSource(DEFAULT_GROUP_MAX_SIZE))
+                .test()
+                .awaitTerminalEvent(2 * DEFAULT_GROUPING_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+                .assertNotCompleted()
+                .assertValueCount(1);
+    }
+
+    @Test
+    public void groupOperations_WithOneOverGroupMaxSizeElements_EmitsTwoGroups() {
+        contentStoreCore.groupOperations(createSource(DEFAULT_GROUP_MAX_SIZE + 1))
+                .test()
+                .awaitTerminalEvent(2 * DEFAULT_GROUPING_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+                .assertNotCompleted()
+                .assertValueCount(2);
+    }
+
+    @Test
+    public void groupOperations_WithThreeTimesGroupMaxSizeElements_EmitsThreeGroups() {
+        contentStoreCore.groupOperations(createSource(3 * DEFAULT_GROUP_MAX_SIZE))
+                .test()
+                .awaitTerminalEvent(2 * DEFAULT_GROUPING_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+                .assertNotCompleted()
+                .assertValueCount(3);
+    }
+
+    @SuppressWarnings({"ReturnOfNull", "ConstantConditions", "ZeroLengthArrayAllocation"})
+    private static class NullContentStore extends ContentProviderStoreCoreBase<Integer> {
+
+        NullContentStore() {
+            super(Mockito.mock(ContentResolver.class));
+        }
+
+        @NonNull
+        @Override
+        protected String getAuthority() {
+            return null;
+        }
+
+        @NonNull
+        @Override
+        protected ContentObserver getContentObserver() {
+            return null;
+        }
+
+        @NonNull
+        @Override
+        protected Uri getContentUri() {
+            return null;
+        }
+
+        @NonNull
+        @Override
+        protected String[] getProjection() {
+            return new String[0];
+        }
+
+        @NonNull
+        @Override
+        protected Integer read(@NonNull Cursor cursor) {
+            return null;
+        }
+
+        @NonNull
+        @Override
+        protected ContentValues getContentValuesForItem(@NonNull Integer item) {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
Fix for https://github.com/reark/reark/issues/162. This solution is not as nice though: when a triggered debounce is followed with a window closing, we'll get two partial buffers one after the other. This could be revisited if a fix for the observed issue is found.