### PR TITLE
Enable overwriting of final fields in OverwritablePojo

### DIFF
--- a/appshared/src/test/java/io/reark/rxgithubapp/shared/pojo/GitHubRepositoryTest.java
+++ b/appshared/src/test/java/io/reark/rxgithubapp/shared/pojo/GitHubRepositoryTest.java
@@ -72,8 +72,8 @@ public class GitHubRepositoryTest {
 
         repo1.overwrite(repo2);
 
-        assertFalse(repo1.equals(repo2));
-        assertEquals(100, repo1.getId());
+        assertEquals(repo1, repo2);
+        assertEquals(200, repo1.getId());
         assertEquals("bar", repo1.getName());
     }
 }

--- a/reark/src/main/java/io/reark/reark/pojo/OverwritablePojo.java
+++ b/reark/src/main/java/io/reark/reark/pojo/OverwritablePojo.java
@@ -60,8 +60,8 @@ public abstract class OverwritablePojo<T extends OverwritablePojo<T>> {
                 continue;
             }
 
-            if (!Modifier.isPublic(modifiers)) {
-                // We want to overwrite also protected and private fields. This allows field access
+            if (!Modifier.isPublic(modifiers) || Modifier.isFinal(modifiers)) {
+                // We want to overwrite also private and final fields. This allows field access
                 // for this instance of the field. The actual field of the class isn't modified.
                 field.setAccessible(true);
             }
@@ -79,9 +79,7 @@ public abstract class OverwritablePojo<T extends OverwritablePojo<T>> {
     }
 
     protected boolean hasIllegalAccessModifiers(int modifiers) {
-        return Modifier.isFinal(modifiers)
-                || Modifier.isStatic(modifiers)
-                || Modifier.isTransient(modifiers);
+        return Modifier.isStatic(modifiers) || Modifier.isTransient(modifiers);
     }
 
     protected boolean isEmpty(@NonNull final Field field, @NonNull final OverwritablePojo<T> pojo) {

--- a/reark/src/test/java/io/reark/reark/pojo/OverwritablePojoTest.java
+++ b/reark/src/test/java/io/reark/reark/pojo/OverwritablePojoTest.java
@@ -67,8 +67,8 @@ public class OverwritablePojoTest {
 
         pojo1.overwrite(pojo2);
 
-        assertFalse(pojo1.equals(pojo2));
-        assertEquals(100, pojo1.id);
+        assertEquals(pojo1, pojo2);
+        assertEquals(200, pojo1.id);
         assertEquals("bar", pojo1.value);
     }
 


### PR DESCRIPTION
This enables using OvewritablePojo base class with Kotlin value classes where fields are final. Expectation is that the overwriting functionality will only ever be used at object creation time, so this shouldn't cause any issues of unexpected object state.